### PR TITLE
StoryConfig and PassageDS implementations

### DIFF
--- a/css/storyeditview.css
+++ b/css/storyeditview.css
@@ -317,6 +317,12 @@ body.zoom-small
   padding-bottom: 0;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
+  overflow: scroll;
+}
+
+.editModal .content
+{
+  margin-bottom: 2em;
 }
 
 body.iOS .editModal
@@ -340,6 +346,11 @@ body.iOS .editModal
   font-family: "Source Code Pro", monospace;
   line-height: 145%;
   background: inherit;
+}
+
+.editModal label
+{
+  font-weight: 600;
 }
 
 .editModal .fullEdit

--- a/js/models/passageDS.js
+++ b/js/models/passageDS.js
@@ -2,10 +2,17 @@
 
 var PassageDS = Passage.extend({
   defaults: {
-    type: 'ds'
+    type: 'ds',
+    top: 0,
+    left: 0,
+    name: 'Untitle DS Passage',
+    text: ''
   },
 
-  template: _.template(''),
+  template: _.template('<tw-passagedata pid="<%- id %>" name="<%- name %>" ' +
+             'type="<%- type %> ' +
+             'position="<%- left %>,<%- top %>">' +
+             '<%- text %></tw-passagedata>'),
 
   initialize: function() {
     console.log('PassageDS.initialize()');
@@ -15,8 +22,22 @@ var PassageDS = Passage.extend({
 
   },
 
+  /**
+   * Publishes the passage to an HTML fragment.
+   *
+   * @param id
+   *   Numeric id to assign to the passage, NOT this one's DB id
+   * @return HTML fragment
+   */
   publish: function(id) {
-    return this.template({});
+    return this.template({
+      id: id,
+      name: this.get('name'),
+      left: this.get('left'),
+      top: this.get('top'),
+      text: this.get('text'),
+      type: this.get('type')
+    });
   }
 
 });

--- a/js/models/passageDS.js
+++ b/js/models/passageDS.js
@@ -5,7 +5,7 @@ var PassageDS = Passage.extend({
     type: 'ds',
     top: 0,
     left: 0,
-    name: 'Untitle DS Passage',
+    name: 'Untitled DS Passage',
     text: ''
   },
 
@@ -15,7 +15,7 @@ var PassageDS = Passage.extend({
              '<%- text %></tw-passagedata>'),
 
   initialize: function() {
-    console.log('PassageDS.initialize()');
+    Passage.prototype.initialize.apply(this);
   },
 
   validate: function(attrs) {

--- a/js/models/passageStoryConfig.js
+++ b/js/models/passageStoryConfig.js
@@ -47,7 +47,7 @@ var PassageStoryConfig = Passage.extend({
     '></tw-passagedata>'),
 
   initialize: function() {
-    console.log('PassageStoryConfig.initialize()');
+    Passage.prototype.initialize.apply(this);
   },
 
   validate: function(attrs) {
@@ -67,6 +67,7 @@ var PassageStoryConfig = Passage.extend({
       name: this.get('name'),
       left: this.get('left'),
       top: this.get('top'),
+      type: this.get('type'),
       description: this.get('description'),
       alpha_wait_oip: this.get('alpha_wait_oip'),
       alpha_start_ask_oip: this.get('alpha_start_ask_oip'),

--- a/js/models/passageStoryConfig.js
+++ b/js/models/passageStoryConfig.js
@@ -31,6 +31,7 @@ var PassageStoryConfig = Passage.extend({
 
   template: _.template('<tw-passagedata pid="<%- id %>" ' +
     'name="<%- name %>" position="<%- left %>,<%- top %>" ' +
+    'type="<%- type %>" ' +
     'description="<%- description %>" ' +
     'alpha_wait_oip="<%- alpha_wait_oip %>" ' +
     'alpha_start_ask_oip="<%- alpha_start_ask_oip %>" ' +

--- a/js/models/passageStoryConfig.js
+++ b/js/models/passageStoryConfig.js
@@ -2,10 +2,48 @@
 
 var PassageStoryConfig = Passage.extend({
   defaults: {
-    type: 'storyConfig'
+    type: 'storyConfig',
+    name: 'Story Configuration',
+    description: '',
+    alpha_wait_oip: 0,
+    alpha_start_ask_oip: 0,
+    beta_join_ask_oip: 0,
+    beta_wait_oip: 0,
+    game_in_progress_oip: 0,
+    game_ended_from_exit_oip: 0,
+    ask_solo_play: 0,
+
+    // Opt-in paths for games created via mobile
+    mc_ask_beta_1_oip: 0,
+    mc_ask_beta_2_oip: 0,
+    mc_invalid_mobile_oip: 0,
+    mc_not_enough_players_oip: 0,
+
+    /* @todo Can this be automatically determined by the formatter */
+    story_start_oip: 0,
+
+    /* @todo This could be something we want to set in the end game models instead */
+    endgame_config: {
+        indiv_message_end_game_format: 'rankings-within-group-based',
+        group_message_end_game_format: 'group-success-failure-based'
+    },
   },
 
-  template: _.template(''),
+  template: _.template('<tw-passagedata pid="<%- id %>" ' +
+    'name="<%- name %>" position="<%- left %>,<%- top %>" ' +
+    'description="<%- description %>" ' +
+    'alpha_wait_oip="<%- alpha_wait_oip %>" ' +
+    'alpha_start_ask_oip="<%- alpha_start_ask_oip %>" ' +
+    'beta_join_ask_oip="<%- beta_join_ask_oip %>" ' +
+    'beta_wait_oip="<%- beta_wait_oip %>" ' +
+    'game_in_progress_oip="<%- game_in_progress_oip %>" ' +
+    'game_ended_from_exit_oip="<%- game_ended_from_exit_oip %>" ' +
+    'ask_solo_play="<%- ask_solo_play %>" ' +
+    'mc_ask_beta_1_oip="<%- mc_ask_beta_1_oip %>" ' +
+    'mc_ask_beta_2_oip="<%- mc_ask_beta_2_oip %>" ' +
+    'mc_invalid_mobile_oip="<%- mc_invalid_mobile_oip %>" ' +
+    'mc_not_enough_players_oip="<%- mc_not_enough_players_oip %>" ' +
+    '></tw-passagedata>'),
 
   initialize: function() {
     console.log('PassageStoryConfig.initialize()');
@@ -15,8 +53,32 @@ var PassageStoryConfig = Passage.extend({
 
   },
 
+  /**
+   * Publishes the passage to an HTML fragment.
+   *
+   * @param id
+   *   Numeric id to assign to the passage, NOT this one's DB id
+   * @return HTML fragment
+   */
   publish: function(id) {
-    return this.template({});
+    return this.template({
+      id: id,
+      name: this.get('name'),
+      left: this.get('left'),
+      top: this.get('top'),
+      description: this.get('description'),
+      alpha_wait_oip: this.get('alpha_wait_oip'),
+      alpha_start_ask_oip: this.get('alpha_start_ask_oip'),
+      beta_join_ask_oip: this.get('beta_join_ask_oip'),
+      beta_wait_oip: this.get('beta_wait_oip'),
+      game_in_progress_oip: this.get('game_in_progress_oip'),
+      game_ended_from_exit_oip: this.get('game_ended_from_exit_oip'),
+      ask_solo_play: this.get('ask_solo_play'),
+      mc_ask_beta_1_oip: this.get('mc_ask_beta_1_oip'),
+      mc_ask_beta_2_oip: this.get('mc_ask_beta_2_oip'),
+      mc_invalid_mobile_oip: this.get('mc_invalid_mobile_oip'),
+      mc_not_enough_players_oip: this.get('mc_not_enough_players_oip')
+    });
   }
 
 });

--- a/js/views/storyeditview/passageDSEditor.js
+++ b/js/views/storyeditview/passageDSEditor.js
@@ -2,10 +2,19 @@
 
 StoryEditView.PassageDSEditor = Backbone.View.extend({
 
+  initialize: function() {
+    this.$el.on('modalhide', _.bind(this.save, this));
+  },
+
   /**
    * Opens modal dialog for editing the passage.
    */
   open: function() {
+    this.$('.passageId').val(this.model.id);
+    this.$('.passageName').val(this.model.get('name'));
+    var text = this.model.get('text');
+    this.$('.passageText').val((text == Passage.prototype.defaults.text) ? '' : text);
+
     this.$el.data('modal').trigger('show');
   },
 
@@ -15,6 +24,32 @@ StoryEditView.PassageDSEditor = Backbone.View.extend({
   close: function()
   {
     this.$el.data('modal').trigger('hide');
+  },
+
+  /**
+   * Save changes made to the model.
+   *
+   * @param e
+   *   Event to stop
+   */
+  save: function(e) {
+    var saveResult;
+
+    saveResult = this.model.save({
+      name: this.$('.passageName').val(),
+      text: this.$('.passageText').val()
+    });
+
+    if (saveResult) {
+      this.$('.alert').remove();
+    }
+    else {
+      // @todo show error message
+    }
+
+    if (e) {
+      e.stopImmediatePropagation();
+    }
   }
 
 });

--- a/js/views/storyeditview/passageStoryConfigEditor.js
+++ b/js/views/storyeditview/passageStoryConfigEditor.js
@@ -67,6 +67,10 @@ StoryEditView.PassageStoryConfigEditor = Backbone.View.extend({
     else {
       // @todo show error message here
     }
+
+    if (e) {
+      e.stopImmediatePropagation();
+    }
   }
 
 });

--- a/js/views/storyeditview/passageStoryConfigEditor.js
+++ b/js/views/storyeditview/passageStoryConfigEditor.js
@@ -3,7 +3,7 @@
 StoryEditView.PassageStoryConfigEditor = Backbone.View.extend({
 
   initialize: function() {
-    // Save when modal's is closed
+    // Save when modal is closed
     this.$el.on('modalhide', _.bind(this.save, this));
   },
 

--- a/js/views/storyeditview/passageStoryConfigEditor.js
+++ b/js/views/storyeditview/passageStoryConfigEditor.js
@@ -2,19 +2,71 @@
 
 StoryEditView.PassageStoryConfigEditor = Backbone.View.extend({
 
+  initialize: function() {
+    // Save when modal's is closed
+    this.$el.on('modalhide', _.bind(this.save, this));
+  },
+
   /**
    * Opens modal dialog for editing the passage.
    */
   open: function() {
+    this.$('.passageId').val(this.model.id);
+    this.$('.passageName').val('Story Configuration');
+    this.$('#edit-sc-description').val(this.model.get('description'));
+    this.$('#edit-sc-alpha-wait-oip').val(this.model.get('alpha_wait_oip'));
+    this.$('#edit-sc-alpha-start-ask-oip').val(this.model.get('alpha_start_ask_oip'));
+    this.$('#edit-sc-beta-join-ask-oip').val(this.model.get('beta_join_ask_oip'));
+    this.$('#edit-sc-beta-wait-oip').val(this.model.get('beta_wait_oip'));
+    this.$('#edit-sc-game-in-progress-oip').val(this.model.get('game_in_progress_oip'));
+    this.$('#edit-sc-game-ended-from-exit-oip').val(this.model.get('game_ended_from_exit_oip'));
+    this.$('#edit-sc-ask-solo-play').val(this.model.get('ask_solo_play'));
+    this.$('#edit-sc-ask-beta-1-oip').val(this.model.get('mc_ask_beta_1_oip'));
+    this.$('#edit-sc-ask-beta-2-oip').val(this.model.get('mc_ask_beta_2_oip'));
+    this.$('#edit-sc-invalid-mobile-oip').val(this.model.get('mc_invalid_mobile_oip'));
+    this.$('#edit-sc-not-enough-players-oip').val(this.model.get('mc_not_enough_players_oip'));
+
     this.$el.data('modal').trigger('show');
   },
 
   /**
    * Closes modal.
    */
-  close: function()
-  {
+  close: function() {
     this.$el.data('modal').trigger('hide');
+  },
+
+  /**
+   * Save changes made to this model.
+   *
+   * @param {Event} e Event to stop
+   */
+  save: function(e) {
+    var saveResult
+      ;
+
+    saveResult = this.model.save({
+      name: this.$('.passageName').val(),
+      description: this.$('#edit-sc-description').val(),
+      alpha_wait_oip: this.$('#edit-sc-alpha-wait-oip').val(),
+      alpha_start_ask_oip: this.$('#edit-sc-alpha-start-ask-oip').val(),
+      beta_join_ask_oip: this.$('#edit-sc-beta-join-ask-oip').val(),
+      beta_wait_oip: this.$('#edit-sc-beta-wait-oip').val(),
+      game_in_progress_oip: this.$('#edit-sc-game-in-progress-oip').val(),
+      game_ended_from_exit_oip: this.$('#edit-sc-game-ended-from-exit-oip').val(),
+      ask_solo_play: this.$('#edit-sc-ask-solo-play').val(),
+      mc_ask_beta_1_oip: this.$('#edit-sc-ask-beta-1-oip').val(),
+      mc_ask_beta_2_oip: this.$('#edit-sc-ask-beta-2-oip').val(),
+      mc_invalid_mobile_oip: this.$('#edit-sc-invalid-mobile-oip').val(),
+      mc_not_enough_players_oip: this.$('#edit-sc-not-enough-players-oip').val()
+    });
+
+    if (saveResult) {
+      this.$('.alert').remove();
+    }
+    else {
+      // @todo show error message here
+    }
   }
 
 });

--- a/templates/storyeditview/passageEditDSModal.html
+++ b/templates/storyeditview/passageEditDSModal.html
@@ -8,8 +8,8 @@
   </p>
 
   <div class="content">
-    <p>
-      Placeholder: passageDSModal
-    </p>
+    <div class="fullEdit">
+      <textarea class="passageText" placeholder="Enter the body text of your passage here. To link to another passage, put two square brackets around its name, [[like this]]."></textarea>
+    </div>
   </div>
 </div>

--- a/templates/storyeditview/passageEditStoryConfigModal.html
+++ b/templates/storyeditview/passageEditStoryConfigModal.html
@@ -4,12 +4,52 @@
   </button>
 
   <p class="title">
-    <input type="text" class="passageName fillin" placeholder="Passage Name">
+    <input type="text" class="passageName block fillin" value="Story Configuration" disabled>
   </p>
 
   <div class="content">
-    <p>
-      Placeholder: passageStoryConfigModal
-    </p>
+    <label for="edit-sc-description">Description</label>
+    <input type="text" id="edit-sc-description" class="block fillin">
+
+    <h3>Start Game Opt-in Paths</h3>
+
+    <label for="edit-sc-alpha-wait-oip">Alpha Wait OIP</label>
+    <input type="number" id="edit-sc-alpha-wait-oip" name="sc-alpha-wait-oip" class="block fillin">
+
+    <label for="edit-sc-alpha-start-ask-oip">Alpha Start Ask OIP</label>
+    <input type="number" id="edit-sc-alpha-start-ask-oip" name="sc-alpha-start-ask-oip" class="block fillin">
+
+    <label for="edit-sc-beta-wait-oip">Beta Wait OIP</label>
+    <input type="number" id="edit-sc-beta-wait-oip" name="sc-beta-wait-oip" class="block fillin">
+
+    <label for="edit-sc-beta-join-ask-oip">Beta Join Ask OIP</label>
+    <input type="number" id="edit-sc-beta-join-ask-oip" name="sc-beta-join-ask-oip" class="block fillin">
+
+    <h3>Ask if player wants to go solo</h3>
+
+    <label for="edit-sc-ask-solo-play">Ask Solo Play OIP</label>
+    <input type="number" id="edit-sc-ask-solo-play" name="sc-ask-solo-play" class="block fillin">
+
+    <h3>Error Messages</h3>
+    <label for="edit-sc-game-in-progress-oip">Game In Progress OIP</label>
+    <input type="number" id="edit-sc-game-in-progress-oip" name="sc-game-in-progress-oip" class="block fillin">
+
+    <label for="edit-sc-game-ended-from-exit-oip">Game Ended From Exit OIP</label>
+    <input type="number" id="edit-sc-game-ended-from-exit-oip" name="sc-game-ended-from-exit-oip" class="block fillin">
+
+    <h3>Mobile Creation Opt-in Paths</h3>
+
+    <label for="edit-sc-ask-beta-1-oip">Ask Beta 1</label>
+    <input type="number" id="edit-sc-ask-beta-1-oip" name="sc-ask-beta-1-oip" class="block fillin">
+
+    <label for="edit-sc-ask-beta-2-oip">Ask Beta 2</label>
+    <input type="number" id="edit-sc-ask-beta-2-oip" name="sc-ask-beta-2-oip" class="block fillin">
+
+    <label for="edit-sc-invalid-mobile-oip">Invalid Mobile</label>
+    <input type="number" id="edit-sc-invalid-mobile-oip" name="sc-invalid-mobile-oip" class="block fillin">
+
+    <label for="edit-sc-not-enough-players-oip">Not Enough Players</label>
+    <input type="number" id="edit-sc-not-enough-players-oip" name="sc-not-enough-players-oip" class="block fillin">
+
   </div>
 </div>


### PR DESCRIPTION
#### What's this PR do?

Adds form elements to the StoryConfig and PassageDS modal editors. Data is saved to local storage like regular passage models and can be published/exported.
#### Where should the reviewer start?
##### PassageDS
- passageDS.js - model
- passageDSEditor - controller
- passageEditDSModel.js - view
##### StoryConfig
- passageStoryConfig.js - model
- passageStoryConfigEditor - controller
- passageEditStoryConfigModel.js - view
#### How should this be manually tested?
- Add a DS Passage and a Story Config  passage
- Verify a UI shows up for them
- Enter data and close the modals
- Refresh the web page and if the data's still there, it works
#### Context?

Don't take this implementation as final. I just needed a way to input data with one or two of our custom passages so that I could start working on the exporter.
#### What are the relevant tickets?
#2, #3
