### PR TITLE
Overriding PassageCollection.model 

### DIFF
--- a/js/collections/passagecollection.js
+++ b/js/collections/passagecollection.js
@@ -9,7 +9,21 @@
 
 var PassageCollection = Backbone.Collection.extend(
 {
-  model: Passage,
+  /**
+   * Collection contains polymorphic models.
+   */
+  model: function(attrs, options) {
+    if (attrs.type === PassageStoryConfig.prototype.defaults.type) {
+      return new PassageStoryConfig(attrs, options);
+    }
+    else if (attrs.type === PassageDS.prototype.defaults.type) {
+      return new PassageDS(attrs, options);
+    }
+    else {
+      return new Passage(attrs, options);
+    }
+  },
+
   localStorage: new Backbone.LocalStorage('twine-passages')
 });
 

--- a/js/models/passageStoryConfig.js
+++ b/js/models/passageStoryConfig.js
@@ -50,6 +50,19 @@ var PassageStoryConfig = Passage.extend({
     Passage.prototype.initialize.apply(this);
   },
 
+  /**
+   * Returns an array of all links in this passage's text. Should just have a single link to the starting node
+   * of the story.
+   *
+   * @param {Boolean} internalOnly
+   *   Only return internal links? (i.e. not http://twinery.org)
+   * @return Array of string names
+   */
+  links: function(internalOnly) {
+    // @todo Assumes starting node will always be named 'L10'. Is this a poor assumption to make/thing to enforce?
+    return ['L10'];
+  },
+
   validate: function(attrs) {
 
   },


### PR DESCRIPTION
#### What's this PR do?

Overrides PassageCollection.model property so the collection supports multiple kinds of Passage models. This fixes our problem of not seeing data published from our custom Passage models (ie - PassageStoryConfig, PassageDS).
#### How should this be manually tested?

When exporting a story, you should see custom properties from the PassageStoryConfig model in the data.
#### Any background context?

This solution follows what's suggested in Backbone documentation: http://backbonejs.org/#Collection-model
