### PR TITLE
change name of endGameIndividualSS, endGameIndidualBT, endGameGroup

### DIFF
--- a/app.html
+++ b/app.html
@@ -94,9 +94,9 @@
 <script src="js/models/apppref.js"></script>
 <script src="js/models/passage.js"></script>
 <script src="js/models/passageDS.js"></script>
-<script src="js/models/passageEndGameGroup.js"></script>
-<script src="js/models/passageEndGameIndividualBT.js"></script>
-<script src="js/models/passageEndGameIndividualSS.js"></script>
+<script src="js/models/passageEndGameGroupSuccessNumberResult.js"></script>
+<script src="js/models/passageEndGameIndivSuperlativeResult.js"></script>
+<script src="js/models/passageEndGameIndivRankResult.js"></script>
 <script src="js/models/passageEndLevel.js"></script>
 <script src="js/models/passageStoryConfig.js"></script>
 <script src="js/models/storyformat.js"></script>
@@ -120,9 +120,9 @@
 <script src="js/views/storyeditview/styleeditor.js"></script>
 <script src="js/views/storyeditview/passageeditor.js"></script>
 <script src="js/views/storyeditview/passageDSEditor.js"></script>
-<script src="js/views/storyeditview/passageEndGameGroupEditor.js"></script>
-<script src="js/views/storyeditview/passageEndGameIndividualBTEditor.js"></script>
-<script src="js/views/storyeditview/passageEndGameIndividualSSEditor.js"></script>
+<script src="js/views/storyeditview/passageEndGameGroupSuccessNumberResultEditor.js"></script>
+<script src="js/views/storyeditview/passageEndGameIndivSuperlativeResultEditor.js"></script>
+<script src="js/views/storyeditview/passageEndGameIndivRankResultEditor.js"></script>
 <script src="js/views/storyeditview/passageEndLevelEditor.js"></script>
 <script src="js/views/storyeditview/passageStoryConfigEditor.js"></script>
 <script src="js/views/storyeditview/marquee.js"></script>

--- a/js/models/passageEndGameGroupSuccessNumberResult.js
+++ b/js/models/passageEndGameGroupSuccessNumberResult.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var PassageEndGameGroup = Passage.extend({
+var PassageEndGameGroupSuccessNumberResult = Passage.extend({
   defaults: {
-    type: 'endGameGroup'
+    type: 'passageEndGameGroupSuccessNumberResult'
   },
 
   template: _.template(''),
 
   initialize: function() {
-    console.log('PassageEndGameGroup.initialize()');
+    console.log('PassageEndGameGroupSuccessNumberResult.initialize()');
   },
 
   validate: function(attrs) {

--- a/js/models/passageEndGameIndivRankResult.js
+++ b/js/models/passageEndGameIndivRankResult.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var PassageEndGameIndividualSS = Passage.extend({
+var PassageEndGameIndivRankResult = Passage.extend({
   defaults: {
-    type: 'endGameIndividualSS'
+    type: 'passageEndGameIndivRankResult'
   },
 
   template: _.template(''),
 
   initialize: function() {
-    console.log('PassageEndGameIndividualSS.initialize()');
+    console.log('PassageEndGameIndivRankResult.initialize()');
   },
 
   validate: function(attrs) {

--- a/js/models/passageEndGameIndivSuperlativeResult.js
+++ b/js/models/passageEndGameIndivSuperlativeResult.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var PassageEndGameIndividualBT = Passage.extend({
+var PassageEndGameIndivSuperlativeResult = Passage.extend({
   defaults: {
-    type: 'endGameIndividualBT'
+    type: 'passageEndGameIndivSuperlativeResult'
   },
 
   template: _.template(''),
 
   initialize: function() {
-    console.log('PassageEndGameIndividualBT.initialize()');
+    console.log('passageEndGameIndivSuperlativeResult.initialize()');
   },
 
   validate: function(attrs) {

--- a/js/views/passageitemview.js
+++ b/js/views/passageitemview.js
@@ -167,17 +167,17 @@ var PassageItemView = Marionette.ItemView.extend(
       this.parentView.passageDSEditor.model = this.model;
       this.parentView.passageDSEditor.open();
     }
-    else if (type == 'endGameGroup') {
-      this.parentView.passageEndGameGroupEditor.model = this.model;
-      this.parentView.passageEndGameGroupEditor.open();
+    else if (type == 'passageEndGameGroupSuccessNumberResult') {
+      this.parentView.passageEndGameGroupSuccessNumberResultEditor.model = this.model;
+      this.parentView.passageEndGameGroupSuccessNumberResultEditor.open();
     }
-    else if (type == 'endGameIndividualBT') {
-      this.parentView.passageEndGameIndividualBTEditor.model = this.model;
-      this.parentView.passageEndGameIndividualBTEditor.open();
+    else if (type == 'passageEndGameIndivSuperlativeResultEditor') {
+      this.parentView.passageEndGameIndivSuperlativeResultEditor.model = this.model;
+      this.parentView.passageEndGameIndivSuperlativeResultEditor.open();
     }
-    else if (type == 'endGameIndividualSS') {
-      this.parentView.passageEndGameIndividualSSEditor.model = this.model;
-      this.parentView.passageEndGameIndividualSSEditor.open();
+    else if (type == 'passageEndGameIndivRankResult') {
+      this.parentView.passageEndGameIndivRankResult.model = this.model;
+      this.parentView.passageEndGameIndivRankResult.open();
     }
     else if (type == 'endLevel') {
       this.parentView.passageEndLevelEditor.model = this.model;

--- a/js/views/storyeditview/passageEndGameGroupSuccessNumberResultEditor.js
+++ b/js/views/storyeditview/passageEndGameGroupSuccessNumberResultEditor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-StoryEditView.PassageEndGameIndividualSSEditor = Backbone.View.extend({
+StoryEditView.PassageEndGameGroupSuccessNumberResultEditor = Backbone.View.extend({
 
   /**
    * Opens modal dialog for editing the passage.

--- a/js/views/storyeditview/passageEndGameIndivRankResultEditor.js
+++ b/js/views/storyeditview/passageEndGameIndivRankResultEditor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-StoryEditView.PassageEndGameGroupEditor = Backbone.View.extend({
+StoryEditView.PassageEndGameIndivRankResultEditor = Backbone.View.extend({
 
   /**
    * Opens modal dialog for editing the passage.

--- a/js/views/storyeditview/passageEndGameIndivSuperlativeResultEditor.js
+++ b/js/views/storyeditview/passageEndGameIndivSuperlativeResultEditor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-StoryEditView.PassageEndGameIndividualBTEditor = Backbone.View.extend({
+StoryEditView.PassageEndGameIndivSuperlativeResultEditor = Backbone.View.extend({
 
   /**
    * Opens modal dialog for editing the passage.

--- a/js/views/storyeditview/storyeditview.js
+++ b/js/views/storyeditview/storyeditview.js
@@ -164,9 +164,9 @@ var StoryEditView = Marionette.CompositeView.extend(
 
     // Editors for custom DS passages
     this.passageDSEditor = new StoryEditView.PassageDSEditor({ el: this.$('#passageDSModal'), parent: this });
-    this.passageEndGameGroupEditor = new StoryEditView.PassageEndGameGroupEditor({ el: this.$('#passageEndGameGroupModal'), parent: this });
-    this.passageEndGameIndividualBTEditor = new StoryEditView.PassageEndGameIndividualBTEditor({ el: this.$('#passageEndGameIndividualBTModal'), parent: this });
-    this.passageEndGameIndividualSSEditor = new StoryEditView.PassageEndGameIndividualSSEditor({ el: this.$('#passageEndGameIndividualSSModal'), parent: this });
+    this.passageEndGameGroupSuccessNumberResultEditor = new StoryEditView.PassageEndGameGroupSuccessNumberResultEditor({ el: this.$('#passageEndGameGroupSuccessNumberResultEditor'), parent: this });
+    this.passageEndGameIndivSuperlativeResultEditor = new StoryEditView.PassageEndGameIndivSuperlativeResultEditor({ el: this.$('#passageEndGameIndivSuperlativeResultEditor'), parent: this });
+    this.passageEndGameIndivRankResultEditor = new StoryEditView.PassageEndGameIndivRankResultEditor({ el: this.$('#passageEndGameIndivRankResultEditor'), parent: this });
     this.passageEndLevelEditor = new StoryEditView.PassageEndLevelEditor({ el: this.$('#passageEndLevelModal'), parent: this });
     this.passageStoryConfigEditor = new StoryEditView.PassageStoryConfigEditor({ el: this.$('#passageStoryConfigModal'), parent: this });
 
@@ -260,16 +260,16 @@ var StoryEditView = Marionette.CompositeView.extend(
     this.addPassage(name, left, top, 'endLevel');
   },
 
-  addPassageEndGameGroup: function(name, left, top) {
-    this.addPassage(name, left, top, 'endGameGroup`');
+  addPassageEndGameGroupSuccessNumberResult: function(name, left, top) {
+    this.addPassage(name, left, top, 'addPassageEndGameGroupSuccessNumberResult');
   },
 
-  addPassageEndGameIndividualBT: function(name, left, top) {
-    this.addPassage(name, left, top, 'endGameIndividualBT');
+  addPassageEndGameIndivSuperlativeResult: function(name, left, top) {
+    this.addPassage(name, left, top, 'addPassageEndGameIndivSuperlativeResult');
   },
 
-  addPassageEndGameIndividualSS: function(name, left, top) {
-    this.addPassage(name, left, top, 'endGameIndividualSS');
+  addPassageEndGameIndivRankResult: function(name, left, top) {
+    this.addPassage(name, left, top, 'addPassageEndGameIndivRankResult');
   },
 
   /**

--- a/js/views/storyeditview/toolbar.js
+++ b/js/views/storyeditview/toolbar.js
@@ -108,16 +108,16 @@ StoryEditView.Toolbar = Backbone.View.extend(
       this.parent.addPassageEndLevel();
     },
 
-    'click #addPassageEndGameGroup': function (e) {
-      this.parent.addPassageEndGameGroup();
+    'click #addPassageEndGameGroupSuccessNumberResult': function (e) {
+      this.parent.addPassageEndGameGroupSuccessNumberResult();
     },
 
-    'click #addPassageEndGameIndividualSS': function (e) {
-      this.parent.addPassageEndGameIndividualSS();
+    'click #addPassageEndGameIndivRankResult': function (e) {
+      this.parent.addPassageEndGameIndivRankResult();
     },
 
-    'click #addPassageEndGameIndividualBT': function (e) {
-      this.parent.addPassageEndGameIndividualBT();
+    'click #addPassageEndGameIndivSuperlativeResult': function (e) {
+      this.parent.addPassageEndGameIndivSuperlativeResult();
     },
 
     'click .testStory': function (e)

--- a/templates/storyeditview/passageEditEndGameGroupSuccessNumberResultModal.html
+++ b/templates/storyeditview/passageEditEndGameGroupSuccessNumberResultModal.html
@@ -1,4 +1,4 @@
-<div id="passageEndGameIndividualSSModal" class="editModal modal hide">
+<div id="passageEndGameGroupSuccessNumberResultModal" class="editModal modal hide">
   <button class="save close subtle" data-modal-hide="this">
     <i class="fa fa-times"></i>
   </button>
@@ -9,7 +9,7 @@
 
   <div class="content">
     <p>
-      Placeholder: passageEndGameIndividualSSModal
+      Placeholder: passageEndGameGroupSuccessNumberResultModal
     </p>
   </div>
 </div>

--- a/templates/storyeditview/passageEditEndGameIndivRankResultModal.html
+++ b/templates/storyeditview/passageEditEndGameIndivRankResultModal.html
@@ -1,4 +1,4 @@
-<div id="passageEndGameGroupModal" class="editModal modal hide">
+<div id="passageEndGameIndivRankResultModal" class="editModal modal hide">
   <button class="save close subtle" data-modal-hide="this">
     <i class="fa fa-times"></i>
   </button>
@@ -9,7 +9,7 @@
 
   <div class="content">
     <p>
-      Placeholder: passageEndGameGroupModal
+      Placeholder: passageEndGameIndivRankResultModal
     </p>
   </div>
 </div>

--- a/templates/storyeditview/passageEditEndGameIndivSuperlativeResultModal.html
+++ b/templates/storyeditview/passageEditEndGameIndivSuperlativeResultModal.html
@@ -1,4 +1,4 @@
-<div id="passageEndGameIndividualBTModal" class="editModal modal hide">
+<div id="passageEndGameIndivSuperlativeResultModal" class="editModal modal hide">
   <button class="save close subtle" data-modal-hide="this">
     <i class="fa fa-times"></i>
   </button>
@@ -9,7 +9,7 @@
 
   <div class="content">
     <p>
-      Placeholder: passageEndGameIndividualBTModal
+      Placeholder: passageEndGameIndivSuperlativeResultModal
     </p>
   </div>
 </div>

--- a/templates/storyeditview/storyeditview.html
+++ b/templates/storyeditview/storyeditview.html
@@ -14,9 +14,9 @@
 <!--(bake /templates/storyeditview/storyformatmodal.html)-->
 
 <!--(bake /templates/storyeditview/passageEditDSModal.html)-->
-<!--(bake /templates/storyeditview/passageEditEndGameGroupModal.html)-->
-<!--(bake /templates/storyeditview/passageEditEndGameIndividualBTModal.html)-->
-<!--(bake /templates/storyeditview/passageEditEndGameIndividualSSModal.html)-->
+<!--(bake /templates/storyeditview/passageEditEndGameGroupSuccessNumberResultModal.html)-->
+<!--(bake /templates/storyeditview/passageEditEndGameIndivSuperlativeResultModal.html)-->
+<!--(bake /templates/storyeditview/passageEditEndGameIndivRankResultModal.html)-->
 <!--(bake /templates/storyeditview/passageEditEndLevelModal.html)-->
 <!--(bake /templates/storyeditview/passageEditStoryConfigModal.html)-->
 

--- a/templates/storyeditview/toolbar.html
+++ b/templates/storyeditview/toolbar.html
@@ -96,7 +96,7 @@
       </li>
       <li>
         <button id="addPassageDS" class="create" title="Add new DS passage" data-tooltip-dir="nw">
-          <i class="fa fa-plus fa-lg"></i> DS Passage
+          <i class="fa fa-plus fa-lg"></i> DoSomething Passage
         </button>
       </li>
       <li>
@@ -106,22 +106,22 @@
       </li>
       <li>
         <button id="addPassageEndLevel" class="create" title="Add new end level passage" data-tooltip-dir="nw">
-          <i class="fa fa-plus fa-lg"></i> End Level
+          <i class="fa fa-plus fa-lg"></i> End Level Result
         </button>
       </li>
       <li>
-        <button id="addPassageEndGameGroup" class="create" title="Add new end game group passage" data-tooltip-dir="nw">
-          <i class="fa fa-plus fa-lg"></i> End Game (Group)
+        <button id="addPassageEndGameGroupSuccessNumberResult" class="create" title="Add new end game group number-of-successes-based results passage (Science Sleuth)" data-tooltip-dir="nw">
+          <i class="fa fa-plus fa-lg"></i> End Game Result, Group Success Number
         </button>
       </li>
       <li>
-        <button id="addPassageEndGameIndividualSS" class="create" title="Add new end game individual passage (Science Sleuth)" data-tooltip-dir="nw">
-          <i class="fa fa-plus fa-lg"></i> End Game (Indiv - SS)
+        <button id="addPassageEndGameIndivRankResult" class="create" title="Add new end game individual rank result passage (Science Sleuth)" data-tooltip-dir="nw">
+          <i class="fa fa-plus fa-lg"></i> End Game Result, Indiv Ranking (SS)
         </button>
       </li>
       <li>
-        <button id="addPassageEndGameIndividualBT" class="create" title="Add new end game individual passage (Bully Test)" data-tooltip-dir="nw">
-          <i class="fa fa-plus fa-lg"></i> End Game (Indiv - BT)
+        <button id="addPassageEndGameIndivSuperlativeResult" class="create" title="Add new end game individual superlative-style result passage (individualized per user based on choice path, i.e. Bully Text)" data-tooltip-dir="nw">
+          <i class="fa fa-plus fa-lg"></i> End Game Result, Indiv Superlative (BT)
         </button>
       </li>
     </ul>


### PR DESCRIPTION
#### What's this PR do?

Changes the names of three custom passage types, and all the attendant references / variations on those names. 

**PASSAGEENDGAMEINDIVIDUALSS**
passageEndGameIndividualSS --> passageEndGameIndivRankResult
passageEndGameIndivRankResultEditor
passageEndGameIndivRankResultModal
passageEditEndGameIndivRankResultModal

**PASSAGEENDGAMEINDIVIDUALBT**
passageEndGameIndividualBT --> passageEndGameIndivSuperlativeResult
passageEndGameIndivSuperlativeResultEditor
passageEndGameIndivSuperlativeResultModal
passageEditEndGameIndivSuperlativeResultModal

**PASSAGEENDGAMEGROUP**
passageEndGameGroup --> passageEndGameGroupSuccessNumberResult
passageEndGameGroupSuccessNumberResultEditor
passageEndGameGroupSuccessNumberResultModal
passageEditEndGameGroupSuccessNumberResultModal
#### How should this be manually tested?

Creating a game with the three passage types, confirming that their content is editable. 
