### PR TITLE
Added exportsms lib to help with exporting story to sms config format

### DIFF
--- a/app.html
+++ b/app.html
@@ -89,6 +89,7 @@
 <script src="lib/codemirror/js/mode/javascript/javascript.js"></script>
 <script src="lib/codemirror/js/mode/css/css.js"></script>
 
+<script src="js/exportsms.js"></script>
 <script src="js/ui.js"></script>
 
 <script src="js/models/apppref.js"></script>

--- a/app.html
+++ b/app.html
@@ -95,9 +95,9 @@
 <script src="js/models/apppref.js"></script>
 <script src="js/models/passage.js"></script>
 <script src="js/models/passageDS.js"></script>
-<script src="js/models/passageEndGameGroup.js"></script>
-<script src="js/models/passageEndGameIndividualBT.js"></script>
-<script src="js/models/passageEndGameIndividualSS.js"></script>
+<script src="js/models/passageEndGameGroupSuccessNumberResult.js"></script>
+<script src="js/models/passageEndGameIndivSuperlativeResult.js"></script>
+<script src="js/models/passageEndGameIndivRankResult.js"></script>
 <script src="js/models/passageEndLevel.js"></script>
 <script src="js/models/passageStoryConfig.js"></script>
 <script src="js/models/storyformat.js"></script>
@@ -121,9 +121,9 @@
 <script src="js/views/storyeditview/styleeditor.js"></script>
 <script src="js/views/storyeditview/passageeditor.js"></script>
 <script src="js/views/storyeditview/passageDSEditor.js"></script>
-<script src="js/views/storyeditview/passageEndGameGroupEditor.js"></script>
-<script src="js/views/storyeditview/passageEndGameIndividualBTEditor.js"></script>
-<script src="js/views/storyeditview/passageEndGameIndividualSSEditor.js"></script>
+<script src="js/views/storyeditview/passageEndGameGroupSuccessNumberResultEditor.js"></script>
+<script src="js/views/storyeditview/passageEndGameIndivSuperlativeResultEditor.js"></script>
+<script src="js/views/storyeditview/passageEndGameIndivRankResultEditor.js"></script>
 <script src="js/views/storyeditview/passageEndLevelEditor.js"></script>
 <script src="js/views/storyeditview/passageStoryConfigEditor.js"></script>
 <script src="js/views/storyeditview/marquee.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -132,6 +132,19 @@ var TwineApp = Backbone.Marionette.Application.extend(
   },
 
   /**
+   * Exports a JSON configuration for DoSomething.org SMS games.
+   *
+   * @param story Story model to export
+   */
+  exportSmsGame: function (story) {
+    var name = story.get('name');
+    var data = story.publish(null, null);
+    
+    var formatted = exportsms.format(data);
+    $('body').html(JSON.stringify(formatted));
+  },
+
+  /**
    Saves an archive of all stories to a file to be downloaded.
 
    @method saveArchive

--- a/js/exportsms.js
+++ b/js/exportsms.js
@@ -80,19 +80,19 @@ var exportsms = function() {
   function _compileStoryConfig(attrs) {
     var data = {};
 
-    data.__comments = attrs.getNamedItem('description') ? attrs.getNamedItem('description').value : '';
-    data.alpha_wait_oip = attrs.getNamedItem('alpha_wait_oip') ? attrs.getNamedItem('alpha_wait_oip').value : 0;
-    data.alpha_start_ask_oip = attrs.getNamedItem('alpha_start_ask_oip') ? attrs.getNamedItem('alpha_start_ask_oip').value : 0;
-    data.beta_join_ask_oip = attrs.getNamedItem('beta_join_ask_oip') ? attrs.getNamedItem('beta_join_ask_oip').value : 0;
-    data.beta_wait_oip = attrs.getNamedItem('beta_wait_oip') ? attrs.getNamedItem('beta_wait_oip').value : 0;
-    data.game_in_progress_oip = attrs.getNamedItem('game_in_progress_oip') ? attrs.getNamedItem('game_in_progress_oip').value : 0;
+    data.__comments =               attrs.getNamedItem('description') ? attrs.getNamedItem('description').value : '';
+    data.alpha_wait_oip =           attrs.getNamedItem('alpha_wait_oip') ? attrs.getNamedItem('alpha_wait_oip').value : 0;
+    data.alpha_start_ask_oip =      attrs.getNamedItem('alpha_start_ask_oip') ? attrs.getNamedItem('alpha_start_ask_oip').value : 0;
+    data.beta_join_ask_oip =        attrs.getNamedItem('beta_join_ask_oip') ? attrs.getNamedItem('beta_join_ask_oip').value : 0;
+    data.beta_wait_oip =            attrs.getNamedItem('beta_wait_oip') ? attrs.getNamedItem('beta_wait_oip').value : 0;
+    data.game_in_progress_oip =     attrs.getNamedItem('game_in_progress_oip') ? attrs.getNamedItem('game_in_progress_oip').value : 0;
     data.game_ended_from_exit_oip = attrs.getNamedItem('game_ended_from_exit_oip') ? attrs.getNamedItem('game_ended_from_exit_oip').value : 0;
-    data.story_start_oip = attrs.getNamedItem('story_start_oip') ? attrs.getNamedItem('story_start_oip').value : 0;
-    data.ask_solo_play = attrs.getNamedItem('ask_solo_play') ? attrs.getNamedItem('ask_solo_play').value : 0;
+    data.story_start_oip =          attrs.getNamedItem('story_start_oip') ? attrs.getNamedItem('story_start_oip').value : 0;
+    data.ask_solo_play =            attrs.getNamedItem('ask_solo_play') ? attrs.getNamedItem('ask_solo_play').value : 0;
     data.mobile_create = {};
-    data.mobile_create.ask_beta_1_oip = attrs.getNamedItem('mc_ask_beta_1_oip') ? attrs.getNamedItem('mc_ask_beta_1_oip').value : 0;
-    data.mobile_create.ask_beta_2_oip = attrs.getNamedItem('mc_ask_beta_2_oip') ? attrs.getNamedItem('mc_ask_beta_2_oip').value : 0;
-    data.mobile_create.invalid_mobile_oip = attrs.getNamedItem('mc_invalid_mobile_oip') ? attrs.getNamedItem('mc_invalid_mobile_oip').value : 0;
+    data.mobile_create.ask_beta_1_oip =         attrs.getNamedItem('mc_ask_beta_1_oip') ? attrs.getNamedItem('mc_ask_beta_1_oip').value : 0;
+    data.mobile_create.ask_beta_2_oip =         attrs.getNamedItem('mc_ask_beta_2_oip') ? attrs.getNamedItem('mc_ask_beta_2_oip').value : 0;
+    data.mobile_create.invalid_mobile_oip =     attrs.getNamedItem('mc_invalid_mobile_oip') ? attrs.getNamedItem('mc_invalid_mobile_oip').value : 0;
     data.mobile_create.not_enough_players_oip = attrs.getNamedItem('mc_not_enough_players_oip') ? attrs.getNamedItem('mc_not_enough_players_oip').value : 0;
 
     return data;

--- a/js/exportsms.js
+++ b/js/exportsms.js
@@ -1,0 +1,105 @@
+/**
+ * Library to help with exporting Twine data, which typically gets published as HTML elements, and converting
+ * it to a JSON string structured for use with the ds-mdata-responder app.
+ */
+
+'use strict';
+
+var exportsms = function() {
+
+  /**
+   * Format a story from HTML elements to the JSON configuration expected for SMS games.
+   *
+   * @param {String} data
+   *   HTML data from a published story
+   * @return JSON string that defines SMS games configuration
+   */
+  function format(data) {
+    var parsedObj,
+        story,
+        children,
+        passage,
+        tagName,
+        passageType,
+        i,
+        j;
+
+    var config = {},
+        passages = [],
+        result = {}
+        ;
+
+    parsedObj = $.parseHTML(data);
+    story = parsedObj[0];
+    if (story.tagName.toUpperCase() == 'TW-STORYDATA') {
+      children = story.children;
+
+      for (i = 0; i < children.length; i++) {
+        // DOM element / passage data
+        passage = children[i];
+
+        // Check tag name and passage type to determine how to process this data
+        tagName = passage.tagName.toUpperCase();
+        passageType = passage.attributes.length > 0 ? passage.attributes.getNamedItem('type') : '';
+
+        if (tagName == 'TW-PASSAGESTORYCONFIGDATA') {
+          config = _compileStoryConfig(passage.attributes);
+        }
+        else if (tagName == 'TW-PASSAGEDATA' && passageType == PassageDS.prototype.defaults.type) {
+          ;
+        }
+        else {
+          // Ignore data that isn't from a custom DS passage
+        }
+      }
+    }
+
+    // Display resulting JSON to the screen
+    result = _merge(result, config);
+
+    return result;
+  }
+
+  /**
+   * Merge obj2 into obj1.
+   */
+  function _merge(obj1, obj2) {
+    for (var name in obj2) {
+      obj1[name] = obj2[name];
+    }
+
+    return obj1;
+  }
+
+  /**
+   * Process data from a story config passage to the structure expected for the SMS game config.
+   *
+   * @param attrs NamedNodeMap of attributes from a DOM element
+   * @return Object
+   */
+  function _compileStoryConfig(attrs) {
+    var data = {};
+
+    data.__comments = attrs.getNamedItem('description') ? attrs.getNamedItem('description').value : '';
+    data.alpha_wait_oip = attrs.getNamedItem('alpha_wait_oip') ? attrs.getNamedItem('alpha_wait_oip').value : 0;
+    data.alpha_start_ask_oip = attrs.getNamedItem('alpha_start_ask_oip') ? attrs.getNamedItem('alpha_start_ask_oip').value : 0;
+    data.beta_join_ask_oip = attrs.getNamedItem('beta_join_ask_oip') ? attrs.getNamedItem('beta_join_ask_oip').value : 0;
+    data.beta_wait_oip = attrs.getNamedItem('beta_wait_oip') ? attrs.getNamedItem('beta_wait_oip').value : 0;
+    data.game_in_progress_oip = attrs.getNamedItem('game_in_progress_oip') ? attrs.getNamedItem('game_in_progress_oip').value : 0;
+    data.game_ended_from_exit_oip = attrs.getNamedItem('game_ended_from_exit_oip') ? attrs.getNamedItem('game_ended_from_exit_oip').value : 0;
+    data.story_start_oip = attrs.getNamedItem('story_start_oip') ? attrs.getNamedItem('story_start_oip').value : 0;
+    data.ask_solo_play = attrs.getNamedItem('ask_solo_play') ? attrs.getNamedItem('ask_solo_play').value : 0;
+    data.mobile_create = {};
+    data.mobile_create.ask_beta_1_oip = attrs.getNamedItem('mc_ask_beta_1_oip') ? attrs.getNamedItem('mc_ask_beta_1_oip').value : 0;
+    data.mobile_create.ask_beta_2_oip = attrs.getNamedItem('mc_ask_beta_2_oip') ? attrs.getNamedItem('mc_ask_beta_2_oip').value : 0;
+    data.mobile_create.invalid_mobile_oip = attrs.getNamedItem('mc_invalid_mobile_oip') ? attrs.getNamedItem('mc_invalid_mobile_oip').value : 0;
+    data.mobile_create.not_enough_players_oip = attrs.getNamedItem('mc_not_enough_players_oip') ? attrs.getNamedItem('mc_not_enough_players_oip').value : 0;
+
+    return data;
+  }
+
+  return {
+    format: format
+  };
+
+}();

--- a/js/models/passageEndGameGroupSuccessNumberResult.js
+++ b/js/models/passageEndGameGroupSuccessNumberResult.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var PassageEndGameGroup = Passage.extend({
+var PassageEndGameGroupSuccessNumberResult = Passage.extend({
   defaults: {
-    type: 'endGameGroup'
+    type: 'passageEndGameGroupSuccessNumberResult'
   },
 
   template: _.template(''),
 
   initialize: function() {
-    console.log('PassageEndGameGroup.initialize()');
+    console.log('PassageEndGameGroupSuccessNumberResult.initialize()');
   },
 
   validate: function(attrs) {

--- a/js/models/passageEndGameIndivRankResult.js
+++ b/js/models/passageEndGameIndivRankResult.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var PassageEndGameIndividualSS = Passage.extend({
+var PassageEndGameIndivRankResult = Passage.extend({
   defaults: {
-    type: 'endGameIndividualSS'
+    type: 'passageEndGameIndivRankResult'
   },
 
   template: _.template(''),
 
   initialize: function() {
-    console.log('PassageEndGameIndividualSS.initialize()');
+    console.log('PassageEndGameIndivRankResult.initialize()');
   },
 
   validate: function(attrs) {

--- a/js/models/passageEndGameIndivSuperlativeResult.js
+++ b/js/models/passageEndGameIndivSuperlativeResult.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var PassageEndGameIndividualBT = Passage.extend({
+var PassageEndGameIndivSuperlativeResult = Passage.extend({
   defaults: {
-    type: 'endGameIndividualBT'
+    type: 'passageEndGameIndivSuperlativeResult'
   },
 
   template: _.template(''),
 
   initialize: function() {
-    console.log('PassageEndGameIndividualBT.initialize()');
+    console.log('passageEndGameIndivSuperlativeResult.initialize()');
   },
 
   validate: function(attrs) {

--- a/js/models/passageStoryConfig.js
+++ b/js/models/passageStoryConfig.js
@@ -29,7 +29,7 @@ var PassageStoryConfig = Passage.extend({
     },
   },
 
-  template: _.template('<tw-passagedata pid="<%- id %>" ' +
+  template: _.template('<tw-passageStoryConfigData pid="<%- id %>" ' +
     'name="<%- name %>" position="<%- left %>,<%- top %>" ' +
     'type="<%- type %>" ' +
     'description="<%- description %>" ' +
@@ -44,7 +44,7 @@ var PassageStoryConfig = Passage.extend({
     'mc_ask_beta_2_oip="<%- mc_ask_beta_2_oip %>" ' +
     'mc_invalid_mobile_oip="<%- mc_invalid_mobile_oip %>" ' +
     'mc_not_enough_players_oip="<%- mc_not_enough_players_oip %>" ' +
-    '></tw-passagedata>'),
+    '></tw-passageStoryConfigData>'),
 
   initialize: function() {
     Passage.prototype.initialize.apply(this);

--- a/js/router.js
+++ b/js/router.js
@@ -72,6 +72,13 @@ var TwineRouter = Backbone.Router.extend(
       window.app.publishStory(story, null, { format: format });
     },
 
+    'stories/:id/smsGame': function (id)
+    {
+      var story = Story.withId(id);
+
+      window.app.exportSmsGame(story);
+    },
+
     '*path': function()
     {
       // default route -- show welcome if the user hasn't already seen it

--- a/js/views/passageitemview.js
+++ b/js/views/passageitemview.js
@@ -167,17 +167,17 @@ var PassageItemView = Marionette.ItemView.extend(
       this.parentView.passageDSEditor.model = this.model;
       this.parentView.passageDSEditor.open();
     }
-    else if (type == 'endGameGroup') {
-      this.parentView.passageEndGameGroupEditor.model = this.model;
-      this.parentView.passageEndGameGroupEditor.open();
+    else if (type == 'passageEndGameGroupSuccessNumberResult') {
+      this.parentView.passageEndGameGroupSuccessNumberResultEditor.model = this.model;
+      this.parentView.passageEndGameGroupSuccessNumberResultEditor.open();
     }
-    else if (type == 'endGameIndividualBT') {
-      this.parentView.passageEndGameIndividualBTEditor.model = this.model;
-      this.parentView.passageEndGameIndividualBTEditor.open();
+    else if (type == 'passageEndGameIndivSuperlativeResultEditor') {
+      this.parentView.passageEndGameIndivSuperlativeResultEditor.model = this.model;
+      this.parentView.passageEndGameIndivSuperlativeResultEditor.open();
     }
-    else if (type == 'endGameIndividualSS') {
-      this.parentView.passageEndGameIndividualSSEditor.model = this.model;
-      this.parentView.passageEndGameIndividualSSEditor.open();
+    else if (type == 'passageEndGameIndivRankResult') {
+      this.parentView.passageEndGameIndivRankResult.model = this.model;
+      this.parentView.passageEndGameIndivRankResult.open();
     }
     else if (type == 'endLevel') {
       this.parentView.passageEndLevelEditor.model = this.model;

--- a/js/views/storyeditview/passageEndGameGroupSuccessNumberResultEditor.js
+++ b/js/views/storyeditview/passageEndGameGroupSuccessNumberResultEditor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-StoryEditView.PassageEndGameIndividualSSEditor = Backbone.View.extend({
+StoryEditView.PassageEndGameGroupSuccessNumberResultEditor = Backbone.View.extend({
 
   /**
    * Opens modal dialog for editing the passage.

--- a/js/views/storyeditview/passageEndGameIndivRankResultEditor.js
+++ b/js/views/storyeditview/passageEndGameIndivRankResultEditor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-StoryEditView.PassageEndGameGroupEditor = Backbone.View.extend({
+StoryEditView.PassageEndGameIndivRankResultEditor = Backbone.View.extend({
 
   /**
    * Opens modal dialog for editing the passage.

--- a/js/views/storyeditview/passageEndGameIndivSuperlativeResultEditor.js
+++ b/js/views/storyeditview/passageEndGameIndivSuperlativeResultEditor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-StoryEditView.PassageEndGameIndividualBTEditor = Backbone.View.extend({
+StoryEditView.PassageEndGameIndivSuperlativeResultEditor = Backbone.View.extend({
 
   /**
    * Opens modal dialog for editing the passage.

--- a/js/views/storyeditview/storyeditview.js
+++ b/js/views/storyeditview/storyeditview.js
@@ -164,9 +164,9 @@ var StoryEditView = Marionette.CompositeView.extend(
 
     // Editors for custom DS passages
     this.passageDSEditor = new StoryEditView.PassageDSEditor({ el: this.$('#passageDSModal'), parent: this });
-    this.passageEndGameGroupEditor = new StoryEditView.PassageEndGameGroupEditor({ el: this.$('#passageEndGameGroupModal'), parent: this });
-    this.passageEndGameIndividualBTEditor = new StoryEditView.PassageEndGameIndividualBTEditor({ el: this.$('#passageEndGameIndividualBTModal'), parent: this });
-    this.passageEndGameIndividualSSEditor = new StoryEditView.PassageEndGameIndividualSSEditor({ el: this.$('#passageEndGameIndividualSSModal'), parent: this });
+    this.passageEndGameGroupSuccessNumberResultEditor = new StoryEditView.PassageEndGameGroupSuccessNumberResultEditor({ el: this.$('#passageEndGameGroupSuccessNumberResultEditor'), parent: this });
+    this.passageEndGameIndivSuperlativeResultEditor = new StoryEditView.PassageEndGameIndivSuperlativeResultEditor({ el: this.$('#passageEndGameIndivSuperlativeResultEditor'), parent: this });
+    this.passageEndGameIndivRankResultEditor = new StoryEditView.PassageEndGameIndivRankResultEditor({ el: this.$('#passageEndGameIndivRankResultEditor'), parent: this });
     this.passageEndLevelEditor = new StoryEditView.PassageEndLevelEditor({ el: this.$('#passageEndLevelModal'), parent: this });
     this.passageStoryConfigEditor = new StoryEditView.PassageStoryConfigEditor({ el: this.$('#passageStoryConfigModal'), parent: this });
 
@@ -260,16 +260,16 @@ var StoryEditView = Marionette.CompositeView.extend(
     this.addPassage(name, left, top, 'endLevel');
   },
 
-  addPassageEndGameGroup: function(name, left, top) {
-    this.addPassage(name, left, top, 'endGameGroup`');
+  addPassageEndGameGroupSuccessNumberResult: function(name, left, top) {
+    this.addPassage(name, left, top, 'addPassageEndGameGroupSuccessNumberResult');
   },
 
-  addPassageEndGameIndividualBT: function(name, left, top) {
-    this.addPassage(name, left, top, 'endGameIndividualBT');
+  addPassageEndGameIndivSuperlativeResult: function(name, left, top) {
+    this.addPassage(name, left, top, 'addPassageEndGameIndivSuperlativeResult');
   },
 
-  addPassageEndGameIndividualSS: function(name, left, top) {
-    this.addPassage(name, left, top, 'endGameIndividualSS');
+  addPassageEndGameIndivRankResult: function(name, left, top) {
+    this.addPassage(name, left, top, 'addPassageEndGameIndivRankResult');
   },
 
   /**

--- a/js/views/storyeditview/storyeditview.js
+++ b/js/views/storyeditview/storyeditview.js
@@ -336,6 +336,14 @@ var StoryEditView = Marionette.CompositeView.extend(
   },
 
   /**
+   * Opens a new tab with the story exported as needed for our SMS config.
+   */
+  exportForSms: function()
+  {
+    window.open('#stories/' + this.model.id + '/smsGame', 'twinestory_proof_' + this.model.id);
+  },
+
+  /**
    Opens a new tab with the proofing copy of this story. This
    will re-use the same tab for a particular story.
 

--- a/js/views/storyeditview/toolbar.js
+++ b/js/views/storyeditview/toolbar.js
@@ -130,6 +130,11 @@ StoryEditView.Toolbar = Backbone.View.extend(
       this.parent.play();
     },
 
+    'click .exportStoryForSms': function (e)
+    {
+      this.parent.exportForSms();
+    },
+
     'click .proofStory': function (e)
     {
       this.parent.proof();

--- a/js/views/storyeditview/toolbar.js
+++ b/js/views/storyeditview/toolbar.js
@@ -108,16 +108,16 @@ StoryEditView.Toolbar = Backbone.View.extend(
       this.parent.addPassageEndLevel();
     },
 
-    'click #addPassageEndGameGroup': function (e) {
-      this.parent.addPassageEndGameGroup();
+    'click #addPassageEndGameGroupSuccessNumberResult': function (e) {
+      this.parent.addPassageEndGameGroupSuccessNumberResult();
     },
 
-    'click #addPassageEndGameIndividualSS': function (e) {
-      this.parent.addPassageEndGameIndividualSS();
+    'click #addPassageEndGameIndivRankResult': function (e) {
+      this.parent.addPassageEndGameIndivRankResult();
     },
 
-    'click #addPassageEndGameIndividualBT': function (e) {
-      this.parent.addPassageEndGameIndividualBT();
+    'click #addPassageEndGameIndivSuperlativeResult': function (e) {
+      this.parent.addPassageEndGameIndivSuperlativeResult();
     },
 
     'click .testStory': function (e)

--- a/templates/storyeditview/passageEditEndGameGroupSuccessNumberResultModal.html
+++ b/templates/storyeditview/passageEditEndGameGroupSuccessNumberResultModal.html
@@ -1,4 +1,4 @@
-<div id="passageEndGameIndividualSSModal" class="editModal modal hide">
+<div id="passageEndGameGroupSuccessNumberResultModal" class="editModal modal hide">
   <button class="save close subtle" data-modal-hide="this">
     <i class="fa fa-times"></i>
   </button>
@@ -9,7 +9,7 @@
 
   <div class="content">
     <p>
-      Placeholder: passageEndGameIndividualSSModal
+      Placeholder: passageEndGameGroupSuccessNumberResultModal
     </p>
   </div>
 </div>

--- a/templates/storyeditview/passageEditEndGameIndivRankResultModal.html
+++ b/templates/storyeditview/passageEditEndGameIndivRankResultModal.html
@@ -1,4 +1,4 @@
-<div id="passageEndGameGroupModal" class="editModal modal hide">
+<div id="passageEndGameIndivRankResultModal" class="editModal modal hide">
   <button class="save close subtle" data-modal-hide="this">
     <i class="fa fa-times"></i>
   </button>
@@ -9,7 +9,7 @@
 
   <div class="content">
     <p>
-      Placeholder: passageEndGameGroupModal
+      Placeholder: passageEndGameIndivRankResultModal
     </p>
   </div>
 </div>

--- a/templates/storyeditview/passageEditEndGameIndivSuperlativeResultModal.html
+++ b/templates/storyeditview/passageEditEndGameIndivSuperlativeResultModal.html
@@ -1,4 +1,4 @@
-<div id="passageEndGameIndividualBTModal" class="editModal modal hide">
+<div id="passageEndGameIndivSuperlativeResultModal" class="editModal modal hide">
   <button class="save close subtle" data-modal-hide="this">
     <i class="fa fa-times"></i>
   </button>
@@ -9,7 +9,7 @@
 
   <div class="content">
     <p>
-      Placeholder: passageEndGameIndividualBTModal
+      Placeholder: passageEndGameIndivSuperlativeResultModal
     </p>
   </div>
 </div>

--- a/templates/storyeditview/storyeditview.html
+++ b/templates/storyeditview/storyeditview.html
@@ -14,9 +14,9 @@
 <!--(bake /templates/storyeditview/storyformatmodal.html)-->
 
 <!--(bake /templates/storyeditview/passageEditDSModal.html)-->
-<!--(bake /templates/storyeditview/passageEditEndGameGroupModal.html)-->
-<!--(bake /templates/storyeditview/passageEditEndGameIndividualBTModal.html)-->
-<!--(bake /templates/storyeditview/passageEditEndGameIndividualSSModal.html)-->
+<!--(bake /templates/storyeditview/passageEditEndGameGroupSuccessNumberResultModal.html)-->
+<!--(bake /templates/storyeditview/passageEditEndGameIndivSuperlativeResultModal.html)-->
+<!--(bake /templates/storyeditview/passageEditEndGameIndivRankResultModal.html)-->
 <!--(bake /templates/storyeditview/passageEditEndLevelModal.html)-->
 <!--(bake /templates/storyeditview/passageEditStoryConfigModal.html)-->
 

--- a/templates/storyeditview/toolbar.html
+++ b/templates/storyeditview/toolbar.html
@@ -100,7 +100,7 @@
       </li>
       <li>
         <button id="addPassageDS" class="create" title="Add new DS passage" data-tooltip-dir="nw">
-          <i class="fa fa-plus fa-lg"></i> DS Passage
+          <i class="fa fa-plus fa-lg"></i> DoSomething Passage
         </button>
       </li>
       <li>
@@ -110,22 +110,22 @@
       </li>
       <li>
         <button id="addPassageEndLevel" class="create" title="Add new end level passage" data-tooltip-dir="nw">
-          <i class="fa fa-plus fa-lg"></i> End Level
+          <i class="fa fa-plus fa-lg"></i> End Level Result
         </button>
       </li>
       <li>
-        <button id="addPassageEndGameGroup" class="create" title="Add new end game group passage" data-tooltip-dir="nw">
-          <i class="fa fa-plus fa-lg"></i> End Game (Group)
+        <button id="addPassageEndGameGroupSuccessNumberResult" class="create" title="Add new end game group number-of-successes-based results passage (Science Sleuth)" data-tooltip-dir="nw">
+          <i class="fa fa-plus fa-lg"></i> End Game Result, Group Success Number
         </button>
       </li>
       <li>
-        <button id="addPassageEndGameIndividualSS" class="create" title="Add new end game individual passage (Science Sleuth)" data-tooltip-dir="nw">
-          <i class="fa fa-plus fa-lg"></i> End Game (Indiv - SS)
+        <button id="addPassageEndGameIndivRankResult" class="create" title="Add new end game individual rank result passage (Science Sleuth)" data-tooltip-dir="nw">
+          <i class="fa fa-plus fa-lg"></i> End Game Result, Indiv Ranking (SS)
         </button>
       </li>
       <li>
-        <button id="addPassageEndGameIndividualBT" class="create" title="Add new end game individual passage (Bully Test)" data-tooltip-dir="nw">
-          <i class="fa fa-plus fa-lg"></i> End Game (Indiv - BT)
+        <button id="addPassageEndGameIndivSuperlativeResult" class="create" title="Add new end game individual superlative-style result passage (individualized per user based on choice path, i.e. Bully Text)" data-tooltip-dir="nw">
+          <i class="fa fa-plus fa-lg"></i> End Game Result, Indiv Superlative (BT)
         </button>
       </li>
     </ul>

--- a/templates/storyeditview/toolbar.html
+++ b/templates/storyeditview/toolbar.html
@@ -38,6 +38,10 @@
 <li class="divider"></li>
 
 <li>
+<button class="exportStoryForSms">Export for SMS</button>
+</li>
+
+<li>
 <button class="proofStory">View Proofing Copy</button>
 </li>
 


### PR DESCRIPTION
#### What's this PR do?

We needed a way to export a story from its twine html data to the JSON config expected by the ds-mdata-responder app. This adds a button and a library to do that. Currently only works for exporting PassageStoryConfig models to JSON.
#### Where should the reviewer start?

The meat of the work is in exportsms.js. Everything else is really just to trigger the export from the UI.
#### How should this be manually tested?
- create a story
- add a story config passage
- select "Export for SMS"
- verify your story config data is there
#### What are the relevant tickets?
#9
