### PR TITLE
add support for passageDS.js and 3 endgame models 

### DIFF
--- a/app.html
+++ b/app.html
@@ -17,6 +17,7 @@
 <link href="css/welcomeview.css" rel="stylesheet" media="screen">
 <link href="css/storylistview.css" rel="stylesheet" media="screen">
 <link href="css/storyeditview.css" rel="stylesheet" media="screen">
+<link href="css/intertwine.css" rel="stylesheet" media="screen">
 <!-- endbuild -->
 
 </head>

--- a/css/intertwine.css
+++ b/css/intertwine.css
@@ -7,3 +7,8 @@
   margin-left: -20em;
   width: 40em;
 }
+
+#passage-ds-text
+{
+  top: 21.5em;
+}

--- a/css/intertwine.css
+++ b/css/intertwine.css
@@ -1,0 +1,9 @@
+/* 
+  Custom styles and overrides of twine.js styles.
+*/
+
+#add-node 
+{
+  margin-left: -20em;
+  width: 40em;
+}

--- a/js/collections/passagecollection.js
+++ b/js/collections/passagecollection.js
@@ -19,6 +19,15 @@ var PassageCollection = Backbone.Collection.extend(
     else if (attrs.type === PassageDS.prototype.defaults.type) {
       return new PassageDS(attrs, options);
     }
+    else if (attrs.type === PassageEndGameIndivSuperlativeResult.prototype.defaults.type) {
+      return new PassageEndGameIndivSuperlativeResult(attrs, options);
+    }
+    else if (attrs.type === PassageEndGameGroupSuccessNumberResult.prototype.defaults.type) {
+      return new PassageEndGameGroupSuccessNumberResult(attrs, options);
+    }
+    else if (attrs.type === PassageEndGameIndivRankResult.prototype.defaults.type) {
+      return new PassageEndGameIndivRankResult(attrs, options);
+    }
     else {
       return new Passage(attrs, options);
     }

--- a/js/models/passageDS.js
+++ b/js/models/passageDS.js
@@ -7,7 +7,10 @@ var PassageDS = Passage.extend({
     left: 0,
     name: 'Untitled DS Passage',
     text: '',
-    optinpath: 0
+    optinpath: 0,
+    groupSuccessPath: false,
+    indivSuccessPath: false,
+    indivSuperlativePath: ''
   },
 
   template: _.template('<tw-passagedata pid="<%- id %>" name="<%- name %>" ' +
@@ -88,7 +91,10 @@ var PassageDS = Passage.extend({
       top: this.get('top'),
       text: this.get('text'),
       type: this.get('type'),
-      optinpath: this.get('optinpath')
+      optinpath: this.get('optinpath'),
+      groupSuccessPath: this.get('groupSuccessPath'),
+      indivSuccessPath: this.get('indivSuccessPath'),
+      indivSuperlativePath: this.get('indivSuperlativePath')
     });
   }
 

--- a/js/models/passageEndGameGroupSuccessNumberResult.js
+++ b/js/models/passageEndGameGroupSuccessNumberResult.js
@@ -15,7 +15,6 @@ var PassageEndGameGroupSuccessNumberResult = Passage.extend({
   },
 
   template: _.template('<tw-passagedata pid="<%- id %>" name="<%- name %>" ' +
-             'type="<%- type %>" ' +
              'position="<%- left %>,<%- top %>" ' +
              'optinpath="<%- optinpath %>" ' +
              'minNumLevelSuccess="<%- minNumLevelSuccess %>" ' +

--- a/js/models/passageEndGameGroupSuccessNumberResult.js
+++ b/js/models/passageEndGameGroupSuccessNumberResult.js
@@ -2,7 +2,10 @@
 
 var PassageEndGameGroupSuccessNumberResult = Passage.extend({
   defaults: {
-    type: 'passageEndGameGroupSuccessNumberResult'
+    type: 'passageEndGameGroupSuccessNumberResult',
+    name: 'Endgame Group Success Number result',
+    description: 'group endgame result, based on number of group success paths traversed',
+    
   },
 
   template: _.template(''),

--- a/js/models/passageEndGameGroupSuccessNumberResult.js
+++ b/js/models/passageEndGameGroupSuccessNumberResult.js
@@ -3,15 +3,28 @@
 var PassageEndGameGroupSuccessNumberResult = Passage.extend({
   defaults: {
     type: 'passageEndGameGroupSuccessNumberResult',
-    name: 'Endgame Group Success Number result',
-    description: 'group endgame result, based on number of group success paths traversed',
-    
+    top: 0,
+    left: 0,
+    name: 'Endgame Group Success Number Result',
+    description: 'group endgame result message, based on the number of levels the group has successfully passed',
+    text: '',
+    optinpath: 0,
+    // how many levels must this group have successfully passed in order for them to receive this message?
+    minNumLevelSuccess: 0,
+    maxNumLevelSuccess: 0
   },
 
-  template: _.template(''),
+  template: _.template('<tw-passagedata pid="<%- id %>" name="<%- name %>" ' +
+             'type="<%- type %>" ' +
+             'position="<%- left %>,<%- top %>" ' +
+             'optinpath="<%- optinpath %>" ' +
+             'minNumLevelSuccess="<%- minNumLevelSuccess %>" ' +
+             'maxNumLevelSuccess="<%- maxNumLevelSuccess %>" ' +
+             '>' +
+             '<%- text %></tw-passagedata>'),
 
   initialize: function() {
-    console.log('PassageEndGameGroupSuccessNumberResult.initialize()');
+    Passage.prototype.initialize.apply(this);
   },
 
   validate: function(attrs) {
@@ -19,7 +32,16 @@ var PassageEndGameGroupSuccessNumberResult = Passage.extend({
   },
 
   publish: function(id) {
-    return this.template({});
+    return this.template({
+      id: id,
+      name: this.get('name'),
+      left: this.get('left'),
+      top: this.get('top'),
+      text: this.get('text'),
+      optinpath: this.get('optinpath'),
+      minNumLevelSuccess: this.get('minNumLevelSuccess'),
+      maxNumLevelSuccess: this.get('maxNumLevelSuccess')
+    });
   }
 
 });

--- a/js/models/passageEndGameIndivRankResult.js
+++ b/js/models/passageEndGameIndivRankResult.js
@@ -2,13 +2,26 @@
 
 var PassageEndGameIndivRankResult = Passage.extend({
   defaults: {
-    type: 'passageEndGameIndivRankResult'
+    type: 'passageEndGameIndivRankResult',
+    top: 0,
+    left: 0,
+    name: 'Endgame Individual Rank Result',
+    description: 'individual endgame rank result message, based on comparing user rank with other players',
+    text: '',
+    optinpath: 0,
+    rank: 0 // 1, 2, 3, 4, 1-tied, 2-tied
   },
 
-  template: _.template(''),
+  template: _.template('<tw-passagedata pid="<%- id %>" name="<%- name %>" ' +
+             'type="<%- type %>" ' +
+             'position="<%- left %>,<%- top %>" ' +
+             'optinpath="<%- optinpath %>" ' +
+             'rank="<%- rank %>" ' +
+             '>' +
+             '<%- text %></tw-passagedata>'),
 
   initialize: function() {
-    console.log('PassageEndGameIndivRankResult.initialize()');
+    Passage.prototype.initialize.apply(this);
   },
 
   validate: function(attrs) {
@@ -16,7 +29,15 @@ var PassageEndGameIndivRankResult = Passage.extend({
   },
 
   publish: function(id) {
-    return this.template({});
+    return this.template({
+      id: id,
+      name: this.get('name'),
+      left: this.get('left'),
+      top: this.get('top'),
+      text: this.get('text'),
+      optinpath: this.get('optinpath'),
+      rank: this.get('rank')
+    });
   }
 
 });

--- a/js/models/passageEndGameIndivRankResult.js
+++ b/js/models/passageEndGameIndivRankResult.js
@@ -13,7 +13,6 @@ var PassageEndGameIndivRankResult = Passage.extend({
   },
 
   template: _.template('<tw-passagedata pid="<%- id %>" name="<%- name %>" ' +
-             'type="<%- type %>" ' +
              'position="<%- left %>,<%- top %>" ' +
              'optinpath="<%- optinpath %>" ' +
              'rank="<%- rank %>" ' +

--- a/js/models/passageEndGameIndivSuperlativeResult.js
+++ b/js/models/passageEndGameIndivSuperlativeResult.js
@@ -14,7 +14,6 @@ var PassageEndGameIndivSuperlativeResult = Passage.extend({
   },
 
   template: _.template('<tw-passagedata pid="<%- id %>" name="<%- name %>" ' +
-             'type="<%- type %>" ' +
              'position="<%- left %>,<%- top %>" ' +
              'optinpath="<%- optinpath %>" ' +
              'pathFlag="<%- pathFlag %>" ' +

--- a/js/models/passageEndGameIndivSuperlativeResult.js
+++ b/js/models/passageEndGameIndivSuperlativeResult.js
@@ -2,13 +2,27 @@
 
 var PassageEndGameIndivSuperlativeResult = Passage.extend({
   defaults: {
-    type: 'passageEndGameIndivSuperlativeResult'
+    type: 'passageEndGameIndivSuperlativeResult',
+    top: 0,
+    left: 0,
+    name: 'Endgame Individual Superlative Result',
+    description: 'individual endgame superlative result message, based on a unique path of OIPs that player has traversed',
+    text: '',
+    optinpath: 0,
+    // flag(s) which mark path(s) that correspond to this result
+    pathFlag: ''
   },
 
-  template: _.template(''),
+  template: _.template('<tw-passagedata pid="<%- id %>" name="<%- name %>" ' +
+             'type="<%- type %>" ' +
+             'position="<%- left %>,<%- top %>" ' +
+             'optinpath="<%- optinpath %>" ' +
+             'pathFlag="<%- pathFlag %>" ' +
+             '>' +
+             '<%- text %></tw-passagedata>'),
 
   initialize: function() {
-    console.log('passageEndGameIndivSuperlativeResult.initialize()');
+    Passage.prototype.initialize.apply(this);
   },
 
   validate: function(attrs) {
@@ -16,7 +30,15 @@ var PassageEndGameIndivSuperlativeResult = Passage.extend({
   },
 
   publish: function(id) {
-    return this.template({});
+    return this.template({
+      id: id,
+      name: this.get('name'),
+      left: this.get('left'),
+      top: this.get('top'),
+      text: this.get('text'),
+      optinpath: this.get('optinpath'),
+      pathFlag: this.get('pathFlag')
+    });
   }
 
 });

--- a/js/views/passageitemview.js
+++ b/js/views/passageitemview.js
@@ -171,13 +171,13 @@ var PassageItemView = Marionette.ItemView.extend(
       this.parentView.passageEndGameGroupSuccessNumberResultEditor.model = this.model;
       this.parentView.passageEndGameGroupSuccessNumberResultEditor.open();
     }
-    else if (type == 'passageEndGameIndivSuperlativeResultEditor') {
+    else if (type == 'passageEndGameIndivSuperlativeResult') {
       this.parentView.passageEndGameIndivSuperlativeResultEditor.model = this.model;
       this.parentView.passageEndGameIndivSuperlativeResultEditor.open();
     }
     else if (type == 'passageEndGameIndivRankResult') {
-      this.parentView.passageEndGameIndivRankResult.model = this.model;
-      this.parentView.passageEndGameIndivRankResult.open();
+      this.parentView.passageEndGameIndivRankResultEditor.model = this.model;
+      this.parentView.passageEndGameIndivRankResultEditor.open();
     }
     else if (type == 'endLevel') {
       this.parentView.passageEndLevelEditor.model = this.model;

--- a/js/views/storyeditview/passageDSEditor.js
+++ b/js/views/storyeditview/passageDSEditor.js
@@ -15,6 +15,9 @@ StoryEditView.PassageDSEditor = Backbone.View.extend({
     var text = this.model.get('text');
     this.$('.passageText').val((text == Passage.prototype.defaults.text) ? '' : text);
     this.$('#edit-ds-oip').val(this.model.get('optinpath'));
+    this.$('#edit-group-success-path').val(this.model.get('groupSuccessPath'));
+    this.$('#edit-indiv-success-path').val(this.model.get('indivSuccessPath'));
+    this.$('#edit-indiv-superlative-path').val(this.model.get('indivSuperlativePath'));
 
     this.$el.data('modal').trigger('show');
   },
@@ -39,7 +42,10 @@ StoryEditView.PassageDSEditor = Backbone.View.extend({
     saveResult = this.model.save({
       name: this.$('.passageName').val(),
       text: this.$('.passageText').val(),
-      optinpath: this.$('#edit-ds-oip').val()
+      optinpath: this.$('#edit-ds-oip').val(),
+      groupSuccessPath: this.$('#edit-group-success-path').val(),
+      indivSuccessPath: this.$('#edit-indiv-success-path').val(),
+      indivSuperlativePath: this.$('#edit-indiv-superlative-path').val()
     });
 
     if (saveResult) {

--- a/js/views/storyeditview/passageDSEditor.js
+++ b/js/views/storyeditview/passageDSEditor.js
@@ -14,7 +14,6 @@ StoryEditView.PassageDSEditor = Backbone.View.extend({
     this.$('.passageName').val(this.model.get('name'));
     var text = this.model.get('text');
     this.$('.passageText').val((text == Passage.prototype.defaults.text) ? '' : text);
-
     this.$('#edit-ds-oip').val(this.model.get('optinpath'));
 
     this.$el.data('modal').trigger('show');

--- a/js/views/storyeditview/passageEndGameGroupSuccessNumberResultEditor.js
+++ b/js/views/storyeditview/passageEndGameGroupSuccessNumberResultEditor.js
@@ -6,6 +6,14 @@ StoryEditView.PassageEndGameGroupSuccessNumberResultEditor = Backbone.View.exten
    * Opens modal dialog for editing the passage.
    */
   open: function() {
+    this.$('.passageId').val(this.model.id);
+    this.$('.passageName').val(this.model.get('name'));
+    var text = this.model.get('text');
+    this.$('.passageText').val((text == Passage.prototype.defaults.text) ? '' : text);
+    this.$('#edit-ds-oip').val(this.model.get('optinpath'));
+    this.$('#edit-min-num-group-success').val(this.model.get('minNumLevelSuccess'));
+    this.$('#edit-max-num-group-success').val(this.model.get('maxNumLevelSuccess '));
+
     this.$el.data('modal').trigger('show');
   },
 
@@ -15,6 +23,35 @@ StoryEditView.PassageEndGameGroupSuccessNumberResultEditor = Backbone.View.exten
   close: function()
   {
     this.$el.data('modal').trigger('hide');
+  },
+
+  /**
+   * Save changes made to the model.
+   *
+   * @param e
+   *   Event to stop
+   */
+  save: function(e) {
+    var saveResult;
+
+    saveResult = this.model.save({
+      name: this.$('.passageName').val(),
+      text: this.$('.passageText').val(),
+      optinpath: this.$('#edit-ds-oip').val(),
+      minNumLevelSuccess: this.$('#edit-min-num-group-success').val(),
+      maxNumLevelSuccess: this.$('#edit-max-num-group-success').val()
+    });
+
+    if (saveResult) {
+      this.$('.alert').remove();
+    }
+    else {
+      // @todo show error message
+    }
+
+    if (e) {
+      e.stopImmediatePropagation();
+    }
   }
 
 });

--- a/js/views/storyeditview/passageEndGameGroupSuccessNumberResultEditor.js
+++ b/js/views/storyeditview/passageEndGameGroupSuccessNumberResultEditor.js
@@ -2,6 +2,10 @@
 
 StoryEditView.PassageEndGameGroupSuccessNumberResultEditor = Backbone.View.extend({
 
+  initialize: function() {
+    this.$el.on('modalhide', _.bind(this.save, this));
+  },
+  
   /**
    * Opens modal dialog for editing the passage.
    */
@@ -12,7 +16,7 @@ StoryEditView.PassageEndGameGroupSuccessNumberResultEditor = Backbone.View.exten
     this.$('.passageText').val((text == Passage.prototype.defaults.text) ? '' : text);
     this.$('#edit-ds-oip').val(this.model.get('optinpath'));
     this.$('#edit-min-num-group-success').val(this.model.get('minNumLevelSuccess'));
-    this.$('#edit-max-num-group-success').val(this.model.get('maxNumLevelSuccess '));
+    this.$('#edit-max-num-group-success').val(this.model.get('maxNumLevelSuccess'));
 
     this.$el.data('modal').trigger('show');
   },

--- a/js/views/storyeditview/passageEndGameIndivRankResultEditor.js
+++ b/js/views/storyeditview/passageEndGameIndivRankResultEditor.js
@@ -2,6 +2,10 @@
 
 StoryEditView.PassageEndGameIndivRankResultEditor = Backbone.View.extend({
 
+  initialize: function() {
+    this.$el.on('modalhide', _.bind(this.save, this));
+  },
+  
   /**
    * Opens modal dialog for editing the passage.
    */

--- a/js/views/storyeditview/passageEndGameIndivRankResultEditor.js
+++ b/js/views/storyeditview/passageEndGameIndivRankResultEditor.js
@@ -6,6 +6,12 @@ StoryEditView.PassageEndGameIndivRankResultEditor = Backbone.View.extend({
    * Opens modal dialog for editing the passage.
    */
   open: function() {
+    this.$('.passageId').val(this.model.id);
+    this.$('.passageName').val(this.model.get('name'));
+    var text = this.model.get('text');
+    this.$('.passageText').val((text == Passage.prototype.defaults.text) ? '' : text);
+    this.$('#edit-ds-oip').val(this.model.get('optinpath'));
+    this.$('#rank').val(this.model.get('rank'));
     this.$el.data('modal').trigger('show');
   },
 
@@ -15,6 +21,34 @@ StoryEditView.PassageEndGameIndivRankResultEditor = Backbone.View.extend({
   close: function()
   {
     this.$el.data('modal').trigger('hide');
+  },
+
+  /**
+   * Save changes made to the model.
+   *
+   * @param e
+   *   Event to stop
+   */
+  save: function(e) {
+    var saveResult;
+
+    saveResult = this.model.save({
+      name: this.$('.passageName').val(),
+      text: this.$('.passageText').val(),
+      optinpath: this.$('#edit-ds-oip').val(),
+      rank: this.$('#rank').val()
+    });
+
+    if (saveResult) {
+      this.$('.alert').remove();
+    }
+    else {
+      // @todo show error message
+    }
+
+    if (e) {
+      e.stopImmediatePropagation();
+    }
   }
 
 });

--- a/js/views/storyeditview/passageEndGameIndivSuperlativeResultEditor.js
+++ b/js/views/storyeditview/passageEndGameIndivSuperlativeResultEditor.js
@@ -2,6 +2,10 @@
 
 StoryEditView.PassageEndGameIndivSuperlativeResultEditor = Backbone.View.extend({
 
+  initialize: function() {
+    this.$el.on('modalhide', _.bind(this.save, this));
+  },
+  
   /**
    * Opens modal dialog for editing the passage.
    */

--- a/js/views/storyeditview/passageEndGameIndivSuperlativeResultEditor.js
+++ b/js/views/storyeditview/passageEndGameIndivSuperlativeResultEditor.js
@@ -6,6 +6,12 @@ StoryEditView.PassageEndGameIndivSuperlativeResultEditor = Backbone.View.extend(
    * Opens modal dialog for editing the passage.
    */
   open: function() {
+    this.$('.passageId').val(this.model.id);
+    this.$('.passageName').val(this.model.get('name'));
+    var text = this.model.get('text');
+    this.$('.passageText').val((text == Passage.prototype.defaults.text) ? '' : text);
+    this.$('#edit-ds-oip').val(this.model.get('optinpath'));
+    this.$('#path-flag').val(this.model.get('pathFlag'));
     this.$el.data('modal').trigger('show');
   },
 
@@ -15,6 +21,34 @@ StoryEditView.PassageEndGameIndivSuperlativeResultEditor = Backbone.View.extend(
   close: function()
   {
     this.$el.data('modal').trigger('hide');
+  },
+
+  /**
+   * Save changes made to the model.
+   *
+   * @param e
+   *   Event to stop
+   */
+  save: function(e) {
+    var saveResult;
+
+    saveResult = this.model.save({
+      name: this.$('.passageName').val(),
+      text: this.$('.passageText').val(),
+      optinpath: this.$('#edit-ds-oip').val(),
+      pathFlag: this.$('#path-flag').val()
+    });
+
+    if (saveResult) {
+      this.$('.alert').remove();
+    }
+    else {
+      // @todo show error message
+    }
+
+    if (e) {
+      e.stopImmediatePropagation();
+    }
   }
 
 });

--- a/js/views/storyeditview/storyeditview.js
+++ b/js/views/storyeditview/storyeditview.js
@@ -261,15 +261,15 @@ var StoryEditView = Marionette.CompositeView.extend(
   },
 
   addPassageEndGameGroupSuccessNumberResult: function(name, left, top) {
-    this.addPassage(name, left, top, 'passageEndGameGroupSuccessNumberResult');
+    this.addPassage(name, left, top, passageEndGameGroupSuccessNumberResult.prototype.defaults.type);
   },
 
   addPassageEndGameIndivSuperlativeResult: function(name, left, top) {
-    this.addPassage(name, left, top, 'passageEndGameIndivSuperlativeResult');
+    this.addPassage(name, left, top, passageEndGameIndivSuperlativeResult.prototype.defaults.type);
   },
 
   addPassageEndGameIndivRankResult: function(name, left, top) {
-    this.addPassage(name, left, top, 'passageEndGameIndivRankResult');
+    this.addPassage(name, left, top, passageEndGameIndivRankResult.prototype.defaults.type);
   },
 
   /**

--- a/js/views/storyeditview/storyeditview.js
+++ b/js/views/storyeditview/storyeditview.js
@@ -164,9 +164,9 @@ var StoryEditView = Marionette.CompositeView.extend(
 
     // Editors for custom DS passages
     this.passageDSEditor = new StoryEditView.PassageDSEditor({ el: this.$('#passageDSModal'), parent: this });
-    this.passageEndGameGroupSuccessNumberResultEditor = new StoryEditView.PassageEndGameGroupSuccessNumberResultEditor({ el: this.$('#passageEndGameGroupSuccessNumberResultEditor'), parent: this });
-    this.passageEndGameIndivSuperlativeResultEditor = new StoryEditView.PassageEndGameIndivSuperlativeResultEditor({ el: this.$('#passageEndGameIndivSuperlativeResultEditor'), parent: this });
-    this.passageEndGameIndivRankResultEditor = new StoryEditView.PassageEndGameIndivRankResultEditor({ el: this.$('#passageEndGameIndivRankResultEditor'), parent: this });
+    this.passageEndGameGroupSuccessNumberResultEditor = new StoryEditView.PassageEndGameGroupSuccessNumberResultEditor({ el: this.$('#passageEndGameGroupSuccessNumberResultModal'), parent: this });
+    this.passageEndGameIndivSuperlativeResultEditor = new StoryEditView.PassageEndGameIndivSuperlativeResultEditor({ el: this.$('#passageEndGameIndivSuperlativeResultModal'), parent: this });
+    this.passageEndGameIndivRankResultEditor = new StoryEditView.PassageEndGameIndivRankResultEditor({ el: this.$('#passageEndGameIndivRankResultModal'), parent: this });
     this.passageEndLevelEditor = new StoryEditView.PassageEndLevelEditor({ el: this.$('#passageEndLevelModal'), parent: this });
     this.passageStoryConfigEditor = new StoryEditView.PassageStoryConfigEditor({ el: this.$('#passageStoryConfigModal'), parent: this });
 
@@ -261,15 +261,15 @@ var StoryEditView = Marionette.CompositeView.extend(
   },
 
   addPassageEndGameGroupSuccessNumberResult: function(name, left, top) {
-    this.addPassage(name, left, top, 'addPassageEndGameGroupSuccessNumberResult');
+    this.addPassage(name, left, top, 'passageEndGameGroupSuccessNumberResult');
   },
 
   addPassageEndGameIndivSuperlativeResult: function(name, left, top) {
-    this.addPassage(name, left, top, 'addPassageEndGameIndivSuperlativeResult');
+    this.addPassage(name, left, top, 'passageEndGameIndivSuperlativeResult');
   },
 
   addPassageEndGameIndivRankResult: function(name, left, top) {
-    this.addPassage(name, left, top, 'addPassageEndGameIndivRankResult');
+    this.addPassage(name, left, top, 'passageEndGameIndivRankResult');
   },
 
   /**

--- a/templates/storyeditview/passageEditDSModal.html
+++ b/templates/storyeditview/passageEditDSModal.html
@@ -10,8 +10,17 @@
   <div class="content">
     <label for="edit-ds-oip">Mobile Commons Opt-in Path</label>
     <input type="number" id="edit-ds-oip" name="ds-oip" class="block fillin" placeholder="Opt-in Path">
-    <div class="fullEdit">
 
+    <label for="edit-group-success-path">Is this a group success path?</label>
+    <input type="text" id="edit-group-success-path" name="ds-oip" class="block fillin" placeholder="true/false/(leave blank)">
+
+    <label for="edit-indiv-success-path">Is this an individual success path?</label>
+    <input type="text" id="edit-indiv-success-path" name="ds-oip" class="block fillin" placeholder="true/(leave blank)">
+
+    <label for="edit-indiv-superlative-path">What individual endgame superlative result does this path produce? (comma-separated)</label>
+    <input type="text" id="edit-indiv-superlative-path" name="ds-oip" class="block fillin" placeholder="ex.: nerdiest,superlative,friendliest">
+
+    <div class="fullEdit" id="passage-ds-text">
       <textarea class="passageText" placeholder="Enter the body text of your passage here. Custom DS formatting follows this pattern: [[display text|link|answer]]."></textarea>
     </div>
   </div>

--- a/templates/storyeditview/passageEditDSModal.html
+++ b/templates/storyeditview/passageEditDSModal.html
@@ -12,13 +12,13 @@
     <input type="number" id="edit-ds-oip" name="ds-oip" class="block fillin" placeholder="Opt-in Path">
 
     <label for="edit-group-success-path">Is this a group success path?</label>
-    <input type="text" id="edit-group-success-path" name="ds-oip" class="block fillin" placeholder="true/false/(leave blank)">
+    <input type="text" id="edit-group-success-path" name="group-success-path" class="block fillin" placeholder="true/false/(leave blank)">
 
     <label for="edit-indiv-success-path">Is this an individual success path?</label>
-    <input type="text" id="edit-indiv-success-path" name="ds-oip" class="block fillin" placeholder="true/(leave blank)">
+    <input type="text" id="edit-indiv-success-path" name="indiv-success-path" class="block fillin" placeholder="true/(leave blank)">
 
     <label for="edit-indiv-superlative-path">What individual endgame superlative result does this path produce? (comma-separated)</label>
-    <input type="text" id="edit-indiv-superlative-path" name="ds-oip" class="block fillin" placeholder="ex.: nerdiest,superlative,friendliest">
+    <input type="text" id="edit-indiv-superlative-path" name="indiv-endgame-superlative" class="block fillin" placeholder="ex.: nerdiest,superlative,friendliest">
 
     <div class="fullEdit" id="passage-ds-text">
       <textarea class="passageText" placeholder="Enter the body text of your passage here. Custom DS formatting follows this pattern: [[display text|link|answer]]."></textarea>

--- a/templates/storyeditview/passageEditDSModal.html
+++ b/templates/storyeditview/passageEditDSModal.html
@@ -10,7 +10,6 @@
   <div class="content">
     <label for="edit-ds-oip">Mobile Commons Opt-in Path</label>
     <input type="number" id="edit-ds-oip" name="ds-oip" class="block fillin" placeholder="Opt-in Path">
-
     <div class="fullEdit">
 
       <textarea class="passageText" placeholder="Enter the body text of your passage here. Custom DS formatting follows this pattern: [[display text|link|answer]]."></textarea>

--- a/templates/storyeditview/passageEditEndGameGroupSuccessNumberResultModal.html
+++ b/templates/storyeditview/passageEditEndGameGroupSuccessNumberResultModal.html
@@ -8,8 +8,17 @@
   </p>
 
   <div class="content">
-    <p>
-      Placeholder: passageEndGameGroupSuccessNumberResultModal
-    </p>
+    <label for="edit-ds-oip">Mobile Commons Opt-in Path</label>
+    <input type="number" id="edit-ds-oip" name="ds-oip" class="block fillin" placeholder="Opt-in Path">
+
+    <label for="edit-min-num-group-success">What's the MINIMUM number of levels the players must have successfully passed in order for them to receive this message?</label>
+    <input type="number" id="edit-min-num-group-success" name="min-num-group-success" class="block fillin" placeholder="0-6">
+
+    <label for="edit-max-num-group-success">What's the MAXIMUM number of levels the players must have successfully passed in order for them to receive this message?</label>
+    <input type="number" id="edit-max-num-group-success" name="max-num-group-success" class="block fillin" placeholder="0-6">
+
+    <div class="fullEdit" id="passage-ds-text">
+      <textarea class="passageText" placeholder="Enter the body text of your passage here. Custom DS formatting follows this pattern: [[display text|link|answer]]."></textarea>
+    </div>
   </div>
 </div>

--- a/templates/storyeditview/passageEditEndGameIndivRankResultModal.html
+++ b/templates/storyeditview/passageEditEndGameIndivRankResultModal.html
@@ -8,8 +8,14 @@
   </p>
 
   <div class="content">
-    <p>
-      Placeholder: passageEndGameIndivRankResultModal
-    </p>
+    <label for="edit-ds-oip">Mobile Commons Opt-in Path</label>
+    <input type="number" id="edit-ds-oip" name="ds-oip" class="block fillin" placeholder="Opt-in Path">
+
+    <label for="rank">How must the user be ranked relative to her peer players in order to receive this result message?</label>
+    <input type="text" id="rank" name="rank" class="block fillin" placeholder="ex. 1, 2, 3, 4, 1-tied, 2-tied">
+
+    <div class="fullEdit" id="passage-ds-text">
+      <textarea class="passageText" placeholder="Enter the body text of your passage here. Custom DS formatting follows this pattern: [[display text|link|answer]]."></textarea>
+    </div>
   </div>
 </div>

--- a/templates/storyeditview/passageEditEndGameIndivSuperlativeResultModal.html
+++ b/templates/storyeditview/passageEditEndGameIndivSuperlativeResultModal.html
@@ -8,8 +8,14 @@
   </p>
 
   <div class="content">
-    <p>
-      Placeholder: passageEndGameIndivSuperlativeResultModal
-    </p>
+    <label for="edit-ds-oip">Mobile Commons Opt-in Path</label>
+    <input type="number" id="edit-ds-oip" name="ds-oip" class="block fillin" placeholder="Opt-in Path">
+
+    <label for="path-flag">What are the names of the flags, or flag, which mark paths corresponding to this result message?</label>
+    <input type="text" id="path-flag" name="path-flag" class="block fillin" placeholder="ex. nerdiest, nerdiest2, bestsmile">
+
+    <div class="fullEdit" id="passage-ds-text">
+      <textarea class="passageText" placeholder="Enter the body text of your passage here. Custom DS formatting follows this pattern: [[display text|link|answer]]."></textarea>
+    </div>
   </div>
 </div>

--- a/templates/storyeditview/toolbar.html
+++ b/templates/storyeditview/toolbar.html
@@ -91,7 +91,7 @@
     <span>Add Node</span>
     <i class="fa fa-caret-up fa-lg"></i>
   </button>
-  <div class="bubble down smaller">
+  <div class="bubble down smaller" id="add-node">
     <ul class="menu">
       <li>
         <button class="addPassage create" title="Add Twine passage" data-tooltip-dir="nw">


### PR DESCRIPTION
#### What's this PR do?

This PR adds models for `passageDS.js`, and the endgame models `passageEndGameGroupSuccessNumberResult.js`, `passageEndGameIndivRankResult.js`, and `passageEndGameIndivSuperlativeResult.js`. 

It also adds a custom css class to `toolbar.html` so that the writing on the toolbar is readable, and a new css overrides file: `intertwine.css`. 

For each type of model, four files have been edited: 
1. the passage model object itself (i.e., passageDS.js)
2. the passage editing object (i.e., passageDSEditor.js)
3. the HTML modal which allows the model to be edited
4. `passagecollection.js`, which allows new passage objects to be returned with collection-level functions
#### Where should the reviewer start?

If I were reviewing this, I'd look over the above four files in that order for each of the new models. 
#### How should this be manually tested?

Creating new passages for the four models, adding data, and confirming that the data remains in the HTML file that gets exported. 
#### What are the relevant tickets?

Closes #6, #5, #4, #3. 
