### PR TITLE
PassageDS models exported to json config

### DIFF
--- a/js/exportsms.js
+++ b/js/exportsms.js
@@ -40,13 +40,13 @@ var exportsms = function() {
 
         // Check tag name and passage type to determine how to process this data
         tagName = passage.tagName.toUpperCase();
-        passageType = passage.attributes.length > 0 ? passage.attributes.getNamedItem('type') : '';
+        passageType = passage.attributes.getNamedItem('type') ? passage.attributes.getNamedItem('type').value : '';
 
         if (tagName == 'TW-PASSAGESTORYCONFIGDATA') {
           config = _compileStoryConfig(passage.attributes);
         }
         else if (tagName == 'TW-PASSAGEDATA' && passageType == PassageDS.prototype.defaults.type) {
-          ;
+          passages.push(_compilePassage(passage));
         }
         else {
           // Ignore data that isn't from a custom DS passage
@@ -56,6 +56,7 @@ var exportsms = function() {
 
     // Display resulting JSON to the screen
     result = _merge(result, config);
+    result = _merge(result, _buildStory(passages));
 
     return result;
   }
@@ -96,6 +97,40 @@ var exportsms = function() {
     data.mobile_create.not_enough_players_oip = attrs.getNamedItem('mc_not_enough_players_oip') ? attrs.getNamedItem('mc_not_enough_players_oip').value : 0;
 
     return data;
+  }
+
+  /**
+   * Get passage data out of passage elements and return as an object with just the info we need.
+   *
+   * @param passage
+   *   Passage data as an HTML tw-passagedata element
+   * @return Object
+   */
+  function _compilePassage(passage) {
+    var data = {};
+    var attrs = passage.attributes;
+
+    data.optinpath = attrs.getNamedItem('optinpath') ? attrs.getNamedItem('optinpath').value : 0;
+    data.name = attrs.getNamedItem('name') ? attrs.getNamedItem('name').value : '';
+    data.text = passage.innerText.trim();
+
+    return data;
+  }
+
+  /**
+   * Build story config out of an array of passage data.
+   *
+   * @param passages
+   *   Array of passages in the story
+   * @return Story object
+   */
+  function _buildStory(passages) {
+    var story;
+
+    // @todo Need to actually convert this into the format expected for our SMS game configs
+    story = {'story': passages};
+
+    return story;
   }
 
   return {

--- a/js/models/passageDS.js
+++ b/js/models/passageDS.js
@@ -6,12 +6,15 @@ var PassageDS = Passage.extend({
     top: 0,
     left: 0,
     name: 'Untitled DS Passage',
-    text: ''
+    text: '',
+    optinpath: 0
   },
 
   template: _.template('<tw-passagedata pid="<%- id %>" name="<%- name %>" ' +
-             'type="<%- type %> ' +
-             'position="<%- left %>,<%- top %>">' +
+             'type="<%- type %>" ' +
+             'position="<%- left %>,<%- top %>" ' +
+             'optinpath="<%- optinpath %>" ' +
+             '>' +
              '<%- text %></tw-passagedata>'),
 
   initialize: function() {
@@ -20,6 +23,54 @@ var PassageDS = Passage.extend({
 
   validate: function(attrs) {
 
+  },
+
+  /**
+   * Returns an array of all links in this passage's text.
+   *
+   * @param internalOnly
+   *   Only return internal links (ie - not http://twinery.org)
+   * @return Array of string names
+   */
+  links: function(internalOnly) {
+    var matches,
+        link,
+        invalidLinks,
+        result,
+        i;
+
+    matches = this.get('text').match(/\[\[.*?\]\]/g);
+    result = [];
+
+    if (matches) {
+      invalidLinks = 0;
+
+      for (i = 0; i < matches.length; i++) {
+        // Link format: [[display text|link|valid answer]]
+        link = matches[i].replace(/\[\[(.+)\|(.+)\|(.+)\]\]/g, '$2');
+
+        if (link != matches[i] && link.length > 0) {
+          result.push(link);
+        }
+        else {
+          // Link format is invalid
+          invalidLinks++;
+        }
+      }
+
+      if (invalidLinks > 0) {
+        ui.notify('There are ' + invalidLinks + ' invalid link(s) detected in passage: ' + this.get('name'));
+      }
+    }
+
+    if (internalOnly) {
+      return _.filter(result, function(link) {
+        return ! /^\w+:\/\/\/?\w/i.test(link);
+      });
+    }
+    else {
+      return result;
+    }
   },
 
   /**
@@ -36,7 +87,8 @@ var PassageDS = Passage.extend({
       left: this.get('left'),
       top: this.get('top'),
       text: this.get('text'),
-      type: this.get('type')
+      type: this.get('type'),
+      optinpath: this.get('optinpath')
     });
   }
 

--- a/js/views/storyeditview/linkmanager.js
+++ b/js/views/storyeditview/linkmanager.js
@@ -192,20 +192,19 @@ StoryEditView.LinkManager = Backbone.View.extend(
     this.svg.clear();
     this.lineCache = {};
 
-    for (var startName in this.passageCache)
-    {
+    for (var startName in this.passageCache) {
       if (! this.passageCache.hasOwnProperty(startName))
         continue;
 
       var links = this.passageCache[startName].links;
-
-      for (var j = links.length - 1; j >= 0; j--)
-      {
-        var endName = links[j];
-        this.drawConnector(startName, endName, drawArrows);
-      };
-    };
-    },
+      if (links) {
+        for (var j = links.length - 1; j >= 0; j--) {
+          var endName = links[j];
+          this.drawConnector(startName, endName, drawArrows);
+        }
+      }
+    }
+  },
 
   /**
    Draws or updates a single connector from one passage to another.
@@ -382,13 +381,14 @@ StoryEditView.LinkManager = Backbone.View.extend(
     {
       var alwaysInclude = (draggedNames.indexOf(startName) != -1);
 
-      for (var i = props.links.length - 1; i >= 0; i--)
-      {
-        var endName = props.links[i];
+      if (props && props.links) {
+        for (var i = props.links.length - 1; i >= 0; i--) {
+          var endName = props.links[i];
 
-        if (alwaysInclude || draggedNames.indexOf(endName) != -1)
-          this.draggedConnectors.push([startName, endName]);  
-      };
+          if (alwaysInclude || draggedNames.indexOf(endName) != -1)
+            this.draggedConnectors.push([startName, endName]);  
+        }
+      }
     }, this);
   },
 

--- a/js/views/storyeditview/passageDSEditor.js
+++ b/js/views/storyeditview/passageDSEditor.js
@@ -15,6 +15,8 @@ StoryEditView.PassageDSEditor = Backbone.View.extend({
     var text = this.model.get('text');
     this.$('.passageText').val((text == Passage.prototype.defaults.text) ? '' : text);
 
+    this.$('#edit-ds-oip').val(this.model.get('optinpath'));
+
     this.$el.data('modal').trigger('show');
   },
 
@@ -37,7 +39,8 @@ StoryEditView.PassageDSEditor = Backbone.View.extend({
 
     saveResult = this.model.save({
       name: this.$('.passageName').val(),
-      text: this.$('.passageText').val()
+      text: this.$('.passageText').val(),
+      optinpath: this.$('#edit-ds-oip').val()
     });
 
     if (saveResult) {

--- a/js/views/storyeditview/storyeditview.js
+++ b/js/views/storyeditview/storyeditview.js
@@ -249,11 +249,11 @@ var StoryEditView = Marionette.CompositeView.extend(
   },
 
   addPassageDS: function(name, left, top) {
-    this.addPassage(name, left, top, 'ds');
+    this.addPassage(name, left, top, PassageDS.prototype.defaults.type);
   },
 
   addStoryConfig: function(name, left, top) {
-    this.addPassage(name, left, top, 'storyConfig');
+    this.addPassage(name, left, top, PassageStoryConfig.prototype.defaults.type);
   },
 
   addPassageEndLevel: function(name, left, top) {

--- a/templates/storyeditview/passageEditDSModal.html
+++ b/templates/storyeditview/passageEditDSModal.html
@@ -8,8 +8,12 @@
   </p>
 
   <div class="content">
-    <div class="fullEdit">
-      <textarea class="passageText" placeholder="Enter the body text of your passage here. To link to another passage, put two square brackets around its name, [[like this]]."></textarea>
+    <label for="edit-ds-oip">Mobile Commons Opt-in Path</label>
+    <input type="number" id="edit-ds-oip" name="ds-oip" class="block fillin" placeholder="Opt-in Path">
+
+    <div class="fullEdit" style="top: 8.5em;">
+
+      <textarea class="passageText" placeholder="Enter the body text of your passage here. Custom DS formatting follows this pattern: [[display text|link|answer]]."></textarea>
     </div>
   </div>
 </div>

--- a/templates/storyeditview/passageEditDSModal.html
+++ b/templates/storyeditview/passageEditDSModal.html
@@ -11,7 +11,7 @@
     <label for="edit-ds-oip">Mobile Commons Opt-in Path</label>
     <input type="number" id="edit-ds-oip" name="ds-oip" class="block fillin" placeholder="Opt-in Path">
 
-    <div class="fullEdit" style="top: 8.5em;">
+    <div class="fullEdit">
 
       <textarea class="passageText" placeholder="Enter the body text of your passage here. Custom DS formatting follows this pattern: [[display text|link|answer]]."></textarea>
     </div>


### PR DESCRIPTION
#### What's this PR do?

PassageDS models are exported to the `story` object of the json config.
#### Where should the reviewer start?
- `passageEditDSModal.html`: Adds the optin path field to the UI modal
- `passageDSEditor.js`: Takes the value of that new field and saves it
- `passageDS.js`
  - Includes `optinpath` in the template when the story is published/exported
  - `links` basically helps to draw the links in the UI using the `[[text|link|answers]]` format
- `linkmanager.js`: No logic changes. Mostly just null checking to clean up some warnings that were showing up in the log
- `exportsms.js`: The meat of the action. `_compilePassage` first parses `tw-passagedata` and stores it as an object that has only the data we care about. Then `_buildStory` runs through all passages and translates it into the format expected for our json config.
#### How should this be manually tested?

This is super handwave-y but drag me over if you have questions about testing
- Create a bunch of PassageDS passages and link them together
- Export for SMS
- Config should look like we expect our SMS game configs to look
#### What are the relevant tickets?
#9
