### PR TITLE
add wercker.yml file for deploying to github pages

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,28 @@
+box: wercker/nodejs
+# Build definition
+build:
+  # The steps that will be executed on build
+  steps:
+    # A step that executes `npm install` command
+    - npm-install
+
+    # A custom script step, name value is used in the UI
+    # and the code value contains the command that get executed
+    - script:
+        name: echo nodejs information
+        code: |
+          echo "node version $(node -v) running"
+          echo "npm version $(npm -v) running"
+
+    - script:
+        name: install grunt-cli
+        code: sudo npm install -g grunt-cli
+
+    - script:
+        name: compile
+        code: grunt
+
+
+
+
+

--- a/wercker.yml
+++ b/wercker.yml
@@ -19,10 +19,23 @@ build:
         code: sudo npm install -g grunt-cli
 
     - script:
-        name: compile
+        name: compile javascripts and views into index.html
         code: grunt
+#Delivers passed build to target
+deploy:
+  steps: 
+    - script: 
+        name: configure git
+        code: |-
+          git config --global user.email $GITHUB_USEREMAIL
+          git config --global user.name $GITHUB_USERNAME
 
-
-
-
-
+          #remove current .git folder
+          rm -rf .git
+    - script: 
+        name: Deploy to github pages 
+        code: |- 
+          git init
+          git add . 
+          git commit -m "deploy commit from $WERCKER_STARTED_BY"
+          git push -f $GIT_REMOTE master:gh-pages

--- a/wercker.yml
+++ b/wercker.yml
@@ -37,5 +37,6 @@ deploy:
         code: |- 
           git init
           git add . 
+          git add -f index.html
           git commit -m "deploy commit from $WERCKER_STARTED_BY"
           git push -f $GIT_REMOTE master:gh-pages


### PR DESCRIPTION
#### What's this PR do?

This adds a wercker.yml file to our repo which facilitates deployment of intertwine to Github pages. Note that on the final deploy step, we've added a command to override the `.gitignore` and include `index.html`, the main view. 
#### How should this be manually tested?

Tested by building on `wercker2` branch, then manually deploying. Check it out [here.](http://dosomething.github.io/intertwine)
#### What are the relevant tickets?

Closes #13.
