### PR TITLE
Editor data added to export + used for imports

### DIFF
--- a/js/exportsms.js
+++ b/js/exportsms.js
@@ -73,28 +73,58 @@ var exportsms = function() {
   }
 
   /**
+   * Helper function to create a position object from a string.
+   *
+   * @param coordinates
+   *   String coordinates {top,left}
+   * @return object
+   */
+  function _getPositionFromString(coordinates) {
+    var pos = {top: 0, left: 0};
+    var comma = 0;
+
+    if (typeof coordinates === 'string') {
+      comma = coordinates.indexOf(',');
+      pos.top = coordinates.substring(0, comma);
+      pos.left = coordinates.substring(comma + 1);
+    }
+
+    return pos;
+  }
+
+  /**
    * Process data from a story config passage to the structure expected for the SMS game config.
    *
    * @param attrs NamedNodeMap of attributes from a DOM element
    * @return Object
    */
   function _compileStoryConfig(attrs) {
-    var data = {};
+    var pos,
+        strPos,
+        data = {};
 
-    data.__comments =               attrs.getNamedItem('description') ? attrs.getNamedItem('description').value : '';
-    data.alpha_wait_oip =           attrs.getNamedItem('alpha_wait_oip') ? attrs.getNamedItem('alpha_wait_oip').value : 0;
-    data.alpha_start_ask_oip =      attrs.getNamedItem('alpha_start_ask_oip') ? attrs.getNamedItem('alpha_start_ask_oip').value : 0;
-    data.beta_join_ask_oip =        attrs.getNamedItem('beta_join_ask_oip') ? attrs.getNamedItem('beta_join_ask_oip').value : 0;
-    data.beta_wait_oip =            attrs.getNamedItem('beta_wait_oip') ? attrs.getNamedItem('beta_wait_oip').value : 0;
-    data.game_in_progress_oip =     attrs.getNamedItem('game_in_progress_oip') ? attrs.getNamedItem('game_in_progress_oip').value : 0;
+    data.__comments               =  attrs.getNamedItem('description') ? attrs.getNamedItem('description').value : '';
+    data.alpha_wait_oip           = attrs.getNamedItem('alpha_wait_oip') ? attrs.getNamedItem('alpha_wait_oip').value : 0;
+    data.alpha_start_ask_oip      = attrs.getNamedItem('alpha_start_ask_oip') ? attrs.getNamedItem('alpha_start_ask_oip').value : 0;
+    data.beta_join_ask_oip        = attrs.getNamedItem('beta_join_ask_oip') ? attrs.getNamedItem('beta_join_ask_oip').value : 0;
+    data.beta_wait_oip            = attrs.getNamedItem('beta_wait_oip') ? attrs.getNamedItem('beta_wait_oip').value : 0;
+    data.game_in_progress_oip     = attrs.getNamedItem('game_in_progress_oip') ? attrs.getNamedItem('game_in_progress_oip').value : 0;
     data.game_ended_from_exit_oip = attrs.getNamedItem('game_ended_from_exit_oip') ? attrs.getNamedItem('game_ended_from_exit_oip').value : 0;
-    data.story_start_oip =          attrs.getNamedItem('story_start_oip') ? attrs.getNamedItem('story_start_oip').value : 0;
-    data.ask_solo_play =            attrs.getNamedItem('ask_solo_play') ? attrs.getNamedItem('ask_solo_play').value : 0;
+    data.story_start_oip          = attrs.getNamedItem('story_start_oip') ? attrs.getNamedItem('story_start_oip').value : 0;
+    data.ask_solo_play            = attrs.getNamedItem('ask_solo_play') ? attrs.getNamedItem('ask_solo_play').value : 0;
     data.mobile_create = {};
-    data.mobile_create.ask_beta_1_oip =         attrs.getNamedItem('mc_ask_beta_1_oip') ? attrs.getNamedItem('mc_ask_beta_1_oip').value : 0;
-    data.mobile_create.ask_beta_2_oip =         attrs.getNamedItem('mc_ask_beta_2_oip') ? attrs.getNamedItem('mc_ask_beta_2_oip').value : 0;
-    data.mobile_create.invalid_mobile_oip =     attrs.getNamedItem('mc_invalid_mobile_oip') ? attrs.getNamedItem('mc_invalid_mobile_oip').value : 0;
+    data.mobile_create.ask_beta_1_oip         = attrs.getNamedItem('mc_ask_beta_1_oip') ? attrs.getNamedItem('mc_ask_beta_1_oip').value : 0;
+    data.mobile_create.ask_beta_2_oip         = attrs.getNamedItem('mc_ask_beta_2_oip') ? attrs.getNamedItem('mc_ask_beta_2_oip').value : 0;
+    data.mobile_create.invalid_mobile_oip     = attrs.getNamedItem('mc_invalid_mobile_oip') ? attrs.getNamedItem('mc_invalid_mobile_oip').value : 0;
     data.mobile_create.not_enough_players_oip = attrs.getNamedItem('mc_not_enough_players_oip') ? attrs.getNamedItem('mc_not_enough_players_oip').value : 0;
+
+    data._twinedata = {};
+    data._twinedata.storyconfig = {};
+    data._twinedata.storyconfig.pos = {};
+    strPos = attrs.getNamedItem('position') ? attrs.getNamedItem('position').value : '0,0';
+    pos = _getPositionFromString(strPos);
+    data._twinedata.storyconfig.pos.top  = pos.top;
+    data._twinedata.storyconfig.pos.left = pos.left;
 
     return data;
   }

--- a/js/exportsms.js
+++ b/js/exportsms.js
@@ -221,7 +221,8 @@ var exportsms = function() {
           pos: {
             top: passage.top,
             left: passage.left
-          }
+          },
+          text: passage.text
         };
 
         // Add passage to the story with optinpath as its key

--- a/js/exportsms.js
+++ b/js/exportsms.js
@@ -76,7 +76,7 @@ var exportsms = function() {
    * Helper function to create a position object from a string.
    *
    * @param coordinates
-   *   String coordinates {top,left}
+   *   String coordinates {left,top}
    * @return object
    */
   function _getPositionFromString(coordinates) {
@@ -85,8 +85,8 @@ var exportsms = function() {
 
     if (typeof coordinates === 'string') {
       comma = coordinates.indexOf(',');
-      pos.top = coordinates.substring(0, comma);
-      pos.left = coordinates.substring(comma + 1);
+      pos.left = coordinates.substring(0, comma);
+      pos.top = coordinates.substring(comma + 1);
     }
 
     return pos;
@@ -103,7 +103,7 @@ var exportsms = function() {
         strPos,
         data = {};
 
-    data.__comments               =  attrs.getNamedItem('description') ? attrs.getNamedItem('description').value : '';
+    data.__comments               = attrs.getNamedItem('description') ? attrs.getNamedItem('description').value : '';
     data.alpha_wait_oip           = attrs.getNamedItem('alpha_wait_oip') ? attrs.getNamedItem('alpha_wait_oip').value : 0;
     data.alpha_start_ask_oip      = attrs.getNamedItem('alpha_start_ask_oip') ? attrs.getNamedItem('alpha_start_ask_oip').value : 0;
     data.beta_join_ask_oip        = attrs.getNamedItem('beta_join_ask_oip') ? attrs.getNamedItem('beta_join_ask_oip').value : 0;
@@ -118,13 +118,17 @@ var exportsms = function() {
     data.mobile_create.invalid_mobile_oip     = attrs.getNamedItem('mc_invalid_mobile_oip') ? attrs.getNamedItem('mc_invalid_mobile_oip').value : 0;
     data.mobile_create.not_enough_players_oip = attrs.getNamedItem('mc_not_enough_players_oip') ? attrs.getNamedItem('mc_not_enough_players_oip').value : 0;
 
-    data._twinedata = {};
-    data._twinedata.storyconfig = {};
-    data._twinedata.storyconfig.pos = {};
     strPos = attrs.getNamedItem('position') ? attrs.getNamedItem('position').value : '0,0';
     pos = _getPositionFromString(strPos);
-    data._twinedata.storyconfig.pos.top  = pos.top;
-    data._twinedata.storyconfig.pos.left = pos.left;
+
+    data._twinedata = {
+      storyconfig: {
+        pos: {
+          top: pos.top,
+          left: pos.left
+        }
+      }
+    };
 
     return data;
   }
@@ -137,12 +141,18 @@ var exportsms = function() {
    * @return Object
    */
   function _compilePassage(passage) {
+    var pos, strPos;
     var data = {};
     var attrs = passage.attributes;
 
     data.optinpath = attrs.getNamedItem('optinpath') ? attrs.getNamedItem('optinpath').value : 0;
     data.name = attrs.getNamedItem('name') ? attrs.getNamedItem('name').value : '';
     data.text = passage.innerText.trim();
+
+    strPos = attrs.getNamedItem('position') ? attrs.getNamedItem('position').value : '0,0';
+    pos = _getPositionFromString(strPos);
+    data.top = pos.top;
+    data.left = pos.left;
 
     return data;
   }
@@ -206,6 +216,15 @@ var exportsms = function() {
           }
         }
 
+        // Store twine data to allow story to be imported properly
+        storyPassage._twinedata = {
+          pos: {
+            top: passage.top,
+            left: passage.left
+          }
+        };
+
+        // Add passage to the story with optinpath as its key
         story[passage.optinpath.toString()] = storyPassage;
       }
       else {

--- a/js/importsms.js
+++ b/js/importsms.js
@@ -39,8 +39,6 @@ var importsms = function() {
     // Parse for story config object
     storyConfig = _parseForStoryConfig(data);
     storyConfig.story = story.id;
-    storyConfig.left = 0;
-    storyConfig.top = 0;
 
     allPassages.create(storyConfig, {wait: true});
 
@@ -97,6 +95,13 @@ var importsms = function() {
       passage.mc_ask_beta_2_oip = data.mobile_create.ask_beta_2_oip;
       passage.mc_invalid_mobile_oip = data.mobile_create.invalid_mobile_oip;
       passage.mc_not_enough_players_oip = data.mobile_create.not_enough_players_oip;
+    }
+
+    if ('_twinedata' in data
+        && 'storyconfig' in data._twinedata
+        && 'pos' in data._twinedata.storyconfig) {
+      passage.top = data._twinedata.storyconfig.pos.top;
+      passage.left = data._twinedata.storyconfig.pos.left;
     }
 
     return passage;

--- a/js/importsms.js
+++ b/js/importsms.js
@@ -144,6 +144,13 @@ var importsms = function() {
       }
     }
 
+    // Find additional editor-specific info under _twinedata
+    if (typeof storyData[optinpath]._twinedata !== 'undefined'
+        && typeof storyData[optinpath]._twinedata.pos !== 'undefined') {
+      passage.top = storyData[optinpath]._twinedata.pos.top;
+      passage.left = storyData[optinpath]._twinedata.pos.left;
+    }
+
     return passage;
   }
 

--- a/js/importsms.js
+++ b/js/importsms.js
@@ -127,7 +127,11 @@ var importsms = function() {
     passage.name = storyData[optinpath].name;
     passage.optinpath = optinpath;
     if (storyData[optinpath].text) {
-      passage.text == storyData[optinpath].text;
+      passage.text = storyData[optinpath].text;
+    }
+    else if (typeof storyData[optinpath]._twinedata !== 'undefined'
+             && storyData[optinpath]._twinedata.text) {
+      passage.text = storyData[optinpath]._twinedata.text;
     }
     else {
       for (i = 0; i < storyData[optinpath].choices.length; i++) {


### PR DESCRIPTION
You'll want to wait on #25 to get merged in first before reviewing this one. The diff will be a lot easier to navigate then.
#### What's this PR do?

Our SMS game json configs in their current state don't have enough information to fully recreate the Intertwine workspace the story was created in. This PR adds that data (text, passage position) to the export.
#### Where should the reviewer start?
###### exportsms.js
- For the story config passage, position data is added to `_twinedata.storyconfig.pos.top/.left`
- For the DS passage, position data is added to each story node at `_twinedata.pos.top/.left`
- The full text of the passage is also added for DS passage at `_twinedata.text`
###### importsms.js
- Story config and DS passages pull this new exported data and use it for creating the new models.
#### How should this be manually tested?
- Create a story and "Export for SMS"
- Save the export as a something.json file
- Import that something.json file
- Verify the imported story's content and workspace match the exported content and workspace
#### What are the relevant tickets?

Closes #26 
