### PR TITLE
add 1) minor changes to importsms.js, passage models, 2) add end level logic to exportsms.js

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -141,6 +141,7 @@ var TwineApp = Backbone.Marionette.Application.extend(
     var data = story.publish(null, null);
     
     var formatted = exportsms.format(data);
+    // Display resulting JSON to the screen
     $('body').html(JSON.stringify(formatted));
   },
 

--- a/js/exportsms.js
+++ b/js/exportsms.js
@@ -127,21 +127,38 @@ var exportsms = function() {
       data[attrName] = attrs[i].value || 0;
     }
 
-    data.text = passage.innerText.trim();
+    data.text = passage.innerText.trim(); // Is this still necessary? 
 
-    strPos = attrs.getNamedItem('position') ? attrs.getNamedItem('position').value : '0,0';
-    pos = _getPositionFromString(strPos);
-
+    pos = _getPositionFromString(data.position);
     data._twinedata = {
-      storyconfig: {
-        pos: {
-          top: pos.top,
-          left: pos.left
-        }
-      }
-    };
+      pos: {
+        top: pos.top,
+        left: pos.left
+      },
+      text: passage.innerText.trim();
+    }
 
     return data;
+  }
+
+  /**
+   * Helper function to create a position object from a string.
+   *
+   * @param coordinates
+   *   String coordinates {left,top}
+   * @return object
+   */
+  function _getPositionFromString(coordinates) {
+    var pos = {top: 0, left: 0};
+    var comma = 0;
+
+    if (typeof coordinates === 'string') {
+      comma = coordinates.indexOf(',');
+      pos.left = coordinates.substring(0, comma);
+      pos.top = coordinates.substring(comma + 1);
+    }
+
+    return pos;
   }
 
   /**
@@ -153,21 +170,22 @@ var exportsms = function() {
   function _buildStoryConfig(passageData) {
     var data = {};
 
-    data.__comments =               passageData.description || '';
-    data.alpha_wait_oip =           passageData.alpha_wait_oip || 0;
-    data.alpha_start_ask_oip =      passageData.alpha_start_ask_oip || 0;
-    data.beta_join_ask_oip =        passageData.beta_join_ask_oip || 0;
-    data.beta_wait_oip =            passageData.beta_wait_oip || 0;
-    data.game_in_progress_oip =     passageData.game_in_progress_oip || 0;
+    data.__comments               = passageData.description || '';
+    data.alpha_wait_oip           = passageData.alpha_wait_oip || 0;
+    data.alpha_start_ask_oip      = passageData.alpha_start_ask_oip || 0;
+    data.beta_join_ask_oip        = passageData.beta_join_ask_oip || 0;
+    data.beta_wait_oip            = passageData.beta_wait_oip || 0;
+    data.game_in_progress_oip     = passageData.game_in_progress_oip || 0;
     data.game_ended_from_exit_oip = passageData.game_ended_from_exit_oip || 0;
-    data.story_start_oip =          passageData.story_start_oip || 0;
-    data.ask_solo_play =            passageData.ask_solo_play || 0;
+    data.story_start_oip          = passageData.story_start_oip || 0;
+    data.ask_solo_play            = passageData.ask_solo_play || 0;
 
     data.mobile_create = {};
-    data.mobile_create.ask_beta_1_oip =         passageData.mc_ask_beta_1_oip || 0;
-    data.mobile_create.ask_beta_2_oip =         passageData.mc_ask_beta_2_oip || 0;
-    data.mobile_create.invalid_mobile_oip =     passageData.mc_invalid_mobile_oip || 0;
+    data.mobile_create.ask_beta_1_oip         = passageData.mc_ask_beta_1_oip || 0;
+    data.mobile_create.ask_beta_2_oip         = passageData.mc_ask_beta_2_oip || 0;
+    data.mobile_create.invalid_mobile_oip     = passageData.mc_invalid_mobile_oip || 0;
     data.mobile_create.not_enough_players_oip = passageData.mc_not_enough_players_oip || 0;
+    data._twinedata                           = passageData._twinedata;
 
     strPos = attrs.getNamedItem('position') ? attrs.getNamedItem('position').value : '0,0';
     pos = _getPositionFromString(strPos);
@@ -239,17 +257,10 @@ var exportsms = function() {
           }
         }
 
-        // Store twine data to allow story to be imported properly
-        storyPassage._twinedata = {
-          pos: {
-            top: passage.top,
-            left: passage.left
-          },
-          text: passage.text
-        };
+        // Store twine spatial and text data to allow story to be imported properly
+        storyPassage._twinedata = passage._twinedata
 
-        // Add passage to the story with optinpath as its key
-        story[passage.optinpath.toString()] = storyPassage;
+        partialStory[passage.optinpath.toString()] = storyPassage;
       }
       else {
         error = 'Warning - multiple passageData with the same optinpath';

--- a/js/exportsms.js
+++ b/js/exportsms.js
@@ -45,8 +45,10 @@ var exportsms = function() {
         if (tagName == 'TW-PASSAGESTORYCONFIGDATA') {
           config = _compileStoryConfig(passage.attributes);
         }
-        else if (tagName == 'TW-PASSAGEDATA' && passageType == PassageDS.prototype.defaults.type) {
-          passages.push(_compilePassage(passage));
+        else if (tagName == 'TW-PASSAGEDATA') {
+          if (passageType == PassageDS.prototype.defaults.type) {
+            passages.push(_compilePassage(passage));
+          }
         }
         else {
           // Ignore data that isn't from a custom DS passage
@@ -54,7 +56,7 @@ var exportsms = function() {
       }
     }
 
-    // Display resulting JSON to the screen
+    // Combine JSON objects into config object. 
     result = _merge(result, config);
     result = _merge(result, _buildStory(passages));
 

--- a/js/exportsms.js
+++ b/js/exportsms.js
@@ -129,7 +129,7 @@ var exportsms = function() {
       data[attrName] = attrs[i].value || 0;
     }
 
-    data.text = passage.innerText.trim(); // Is this still necessary? 
+    data.text = passage.innerText.trim();
 
     pos = _getPositionFromString(data.position);
     data._twinedata = {
@@ -327,19 +327,17 @@ var exportsms = function() {
         endLevelGroupLink = passageDatum.text.match(/\[\[.*?\]\]/g)[0];
         endLevelGroupKey = endLevelGroupLink.replace(/\[\[(.+)\|(.+)\|(.+)\]\]/g, '$2');
         endLevelGroupSuccessFailureStatus = endLevelGroupLink.toUpperCase().match(/(SUCCESS|FAILURE)/g)[0];
-        endLevelGroupConfigObject = (partialStory[nameString + "-GROUP"] || { "choices" : [ {"__comments": "SUCCESS"}, {"__comments": "FAILURE"} ], "next_level": 0 });
+        endLevelGroupConfigObject = (partialStory[nameString + "-GROUP"] || { "choices" : [ {"flag": "SUCCESS"}, {"flag": "FAILURE"} ], "next_level": 0 });
 
         for (j = 0; j < endLevelGroupConfigObject.choices.length; j ++) {
           choice = endLevelGroupConfigObject.choices[j];
           // Matching the link contained within the end-level-individual passage to either the 'SUCCESS' or 'FAILURE' 
           // END-LEVELX-GROUP choices
-          if (endLevelGroupSuccessFailureStatus == choice.__comments.toUpperCase()) {
+          if (endLevelGroupSuccessFailureStatus == choice.flag.toUpperCase()) {
             if (!choice.conditions){
               choice.conditions = { "$or" : [] };
             }
-            choice.conditions["$or"].push({
-              "$and": [passageDatum.name] // Is the '$and' necessary, or can I just push the key in the '$or' array?
-            })
+            choice.conditions["$or"].push(passageDatum.name);
             partialStory[nameString + "-GROUP"] = endLevelGroupConfigObject;
             break;
           }
@@ -349,13 +347,13 @@ var exportsms = function() {
       // If this passageDatum is data from a group end-level result passage
       else if (passageDatum.type == PassageEndLevelGroup.prototype.defaults.type) {
         nameString = "END-LEVEL" + levelNumber + "-GROUP";
-        configObject = (partialStory[nameString] || { "choices" : [ {"__comments": "SUCCESS"}, {"__comments": "FAILURE"} ], "next_level": 0 });
+        configObject = (partialStory[nameString] || { "choices" : [ {"flag": "SUCCESS"}, {"flag": "FAILURE"} ], "next_level": 0 });
         endLevelGroupSuccessFailureStatus = passageDatum.name.toUpperCase().match(/(SUCCESS|FAILURE)/g)[0];
         console.log(endLevelGroupSuccessFailureStatus, 'endLevelGroupSuccessFailureStatus')
 
         for (j = 0; j < configObject.choices.length; j ++) {
           choice = configObject.choices[j];
-          if (endLevelGroupSuccessFailureStatus == choice.__comments.toUpperCase() && !choice.next) {
+          if (endLevelGroupSuccessFailureStatus == choice.flag.toUpperCase() && !choice.next) {
             choice.next = parseInt(passageDatum.optinpath, 10);
             partialStory[nameString] = configObject;
             break;

--- a/js/exportsms.js
+++ b/js/exportsms.js
@@ -120,6 +120,7 @@ var exportsms = function() {
     var data = {}
       , attrs = passage.attributes
       , i
+      , pos
       ; 
 
     for (i = 0; i < attrs.length; i ++) {
@@ -135,7 +136,7 @@ var exportsms = function() {
         top: pos.top,
         left: pos.left
       },
-      text: passage.innerText.trim();
+      text: passage.innerText.trim()
     }
 
     return data;
@@ -186,11 +187,6 @@ var exportsms = function() {
     data.mobile_create.invalid_mobile_oip     = passageData.mc_invalid_mobile_oip || 0;
     data.mobile_create.not_enough_players_oip = passageData.mc_not_enough_players_oip || 0;
     data._twinedata                           = passageData._twinedata;
-
-    strPos = attrs.getNamedItem('position') ? attrs.getNamedItem('position').value : '0,0';
-    pos = _getPositionFromString(strPos);
-    data.top = pos.top;
-    data.left = pos.left;
 
     return data;
   }

--- a/js/importsms.js
+++ b/js/importsms.js
@@ -98,10 +98,9 @@ var importsms = function() {
     }
 
     if ('_twinedata' in data
-        && 'storyconfig' in data._twinedata
-        && 'pos' in data._twinedata.storyconfig) {
-      passage.top = data._twinedata.storyconfig.pos.top;
-      passage.left = data._twinedata.storyconfig.pos.left;
+        && 'pos' in data._twinedata) {
+      passage.top = data._twinedata.pos.top;
+      passage.left = data._twinedata.pos.left;
     }
 
     return passage;

--- a/js/models/passageEndGameGroupSuccessNumberResult.js
+++ b/js/models/passageEndGameGroupSuccessNumberResult.js
@@ -15,6 +15,7 @@ var PassageEndGameGroupSuccessNumberResult = Passage.extend({
   },
 
   template: _.template('<tw-passagedata pid="<%- id %>" name="<%- name %>" ' +
+             'type="<%- type %>" ' +
              'position="<%- left %>,<%- top %>" ' +
              'optinpath="<%- optinpath %>" ' +
              'minNumLevelSuccess="<%- minNumLevelSuccess %>" ' +
@@ -37,6 +38,7 @@ var PassageEndGameGroupSuccessNumberResult = Passage.extend({
       left: this.get('left'),
       top: this.get('top'),
       text: this.get('text'),
+      type: this.get('type'),
       optinpath: this.get('optinpath'),
       minNumLevelSuccess: this.get('minNumLevelSuccess'),
       maxNumLevelSuccess: this.get('maxNumLevelSuccess')

--- a/js/models/passageEndGameIndivRankResult.js
+++ b/js/models/passageEndGameIndivRankResult.js
@@ -13,6 +13,7 @@ var PassageEndGameIndivRankResult = Passage.extend({
   },
 
   template: _.template('<tw-passagedata pid="<%- id %>" name="<%- name %>" ' +
+             'type="<%- type %>" ' +
              'position="<%- left %>,<%- top %>" ' +
              'optinpath="<%- optinpath %>" ' +
              'rank="<%- rank %>" ' +
@@ -34,6 +35,7 @@ var PassageEndGameIndivRankResult = Passage.extend({
       left: this.get('left'),
       top: this.get('top'),
       text: this.get('text'),
+      type: this.get('type'),
       optinpath: this.get('optinpath'),
       rank: this.get('rank')
     });

--- a/js/models/passageEndGameIndivSuperlativeResult.js
+++ b/js/models/passageEndGameIndivSuperlativeResult.js
@@ -14,6 +14,7 @@ var PassageEndGameIndivSuperlativeResult = Passage.extend({
   },
 
   template: _.template('<tw-passagedata pid="<%- id %>" name="<%- name %>" ' +
+             'type="<%- type %>" ' +
              'position="<%- left %>,<%- top %>" ' +
              'optinpath="<%- optinpath %>" ' +
              'pathFlag="<%- pathFlag %>" ' +
@@ -35,6 +36,7 @@ var PassageEndGameIndivSuperlativeResult = Passage.extend({
       left: this.get('left'),
       top: this.get('top'),
       text: this.get('text'),
+      type: this.get('type'),
       optinpath: this.get('optinpath'),
       pathFlag: this.get('pathFlag')
     });

--- a/js/models/passageEndLevelGroup.js
+++ b/js/models/passageEndLevelGroup.js
@@ -16,6 +16,7 @@ var PassageEndLevelGroup = Passage.extend({
              'position="<%- left %>,<%- top %>" ' +
              'optinpath="<%- optinpath %>" ' +
              'groupSuccessPath="<%- groupSuccessPath %>" ' +
+             '>' +
              '<%- text %></tw-passagedata>'),
 
   initialize: function() {


### PR DESCRIPTION
#### What's this PR do?
1.  A few things have changed. Previously, the `_twinedata` property for the one storyconfig passage object was  set up to be embedded within the global `_twinedata` property object in the story config object (see below), while all the other passages' `_twinedata` objects did not have an additional nested property like `storyconfig`.

The previous setup for the top-level `_twinedata` object configuring the storyconfig passage: 

```
{ 
        "_id": 100,
        "__comments": "Bully Text 2014",
        "alpha_wait_oip": 169841,
        "alpha_start_ask_oip": 169843,
        "beta_join_ask_oip": 169845,
        "beta_wait_oip": 169847,
        ...
        _twinedata: {
            storyconfig: {
               pos: { } 
            }
        }
}
```

We've removed this additional nested `storyconfig` property so that now, the top-level `_twinedata` object is now formatted like the `_twinedata` objects for all the other passages. The corresponding logic for the importer has also been changed. 

```
{ 
        "_id": 100,
        "__comments": "Bully Text 2014",
        "alpha_wait_oip": 169841,
        "alpha_start_ask_oip": 169843,
        "beta_join_ask_oip": 169845,
        "beta_wait_oip": 169847,
        ...
        _twinedata: {
            {
               pos: { } 
            }
        }
}
```
1. The structure of `exportsms` has also changed. Previously, the exporter had a top-level `format()` function, which sorted passage types and called either `_compileStoryConfig` or `_compilePassage` functions on the data. The HTML elements would be parsed for meaningful data within those respective functions. Now, the exporter's `format()` function runs all passages through an `_extactHTMLData` function first, and then checks passage types to first sort the passages, and then run those sorted arrays through various `_build` functions. (`_buildRegularLevels()`, `_buildEndgame()`, `_buildStoryConfig`).
2. Finally, support for exporting end-level individual and end-level group passages to the JSON config has been added. 

**There are, however, a few things to keep in mind:** 
1. We need to change the names of group end level passages in twine to “END-LEVEL1-GROUP-FAILURE” or “END-LEVEL1-GROUP-SUCCESS”. 
2. We can keep having one group endlevel passage for both success and failure (one for success, one for failure)
3. The config file now will require a `__comments` flag to each one of the things in the END_LEVEL1-GROUP choices object marking the object as either “SUCCESS” or “FAILURE”. The exporter automatically builds in these `__comments` flags, and I’m guessing that we’ll need to have these flags added in the config file for the import to successfully take place. 
4. We've changed the key naming conventions for each passage. Previously, we had keys written like: `L61A`, or `L62C`. Now, our keys are written like `L1A`, `L1AB`. (Second character: level. Third character: user's first response. Fourth character: user's second response. If there's no fourth character, the key corresponds to the passage sent after the first choice.) 
5. Because of the above, each `END-LEVELX` object will now contain choice objects that only need to reference one key (see below.) 

```
            "END-LEVEL1": {
                "choices": [
                    {
                        "next": 169865,
                        "conditions": {
                            "$and": [
                                "L1AA"
                            ]
                        }
                    },
                    {
                        "next": 169867,
                        "conditions": {
                            "$and": [
                                "L1AB"
                            ]
                        }
                    },
                    {
                        "next": 169869,
                        "conditions": {
                            "$and": [
                                "L1BA"
                            ]
                        }
                    },
                    {
                        "next": 169871,
                        "conditions": {
                            "$and": [
                                "L1BB"
                            ]
                        }
                    }
                ]
            },
```
1. In order to simplify the assembling of the `$and`/`$or` logic statements in `END-LEVELX-GROUP` objects, we made an important change: instead of having two choice objects with one containing an array of `$and` conditions and the other containing an array of `$or` conditions, we're going to have two choice objects, each with a top-level `$or` array containing lower-level `$and` arrays. Each `$and` array contains a single key. 

**previous structure:**

```
            "END-LEVEL1-GROUP": {
                "choices": [
                    {
                        "next": 169873,
                        "__comments": "SUCCESS",
                        "conditions": {
                            "$and": [
                                "L1BB"
                            ]
                        }
                    },
                    {
                        "next": 169875,
                        "__comments": "SUCCESS",
                        "conditions": {
                            "$or": [
                                "L1AA",
                                "L1AB",
                                "L1BA"
                            ]
                        }
                    }
                ],
                "next_level": 169877
            },
```

**current modified structure:**

```
        "END-LEVEL1-GROUP": {
            "choices": [
                {
                    "__comments": "SUCCESS",
                    "conditions": {
                        "$or": [
                            {
                                "$and": [
                                    "L1AA"
                                ]
                            }
                        ]
                    },
                    "next": 12345
                },
                {
                    "__comments": "FAILURE",
                    "conditions": {
                        "$or": [
                            {
                                "$and": [
                                    "L1BB"
                                ]
                            },
                            {
                                "$and": [
                                    "L1BA"
                                ]
                            },
                            {
                                "$and": [
                                    "L1AB"
                                ]
                            }
                        ]
                    }
                }
            ],
            "next_level": 0
        }
```
#### Where should the reviewer start?

I'd first look into the simpler changes with `importsms.js`. Then, I'd see how the structure within `exportsms.js` has changed. Finally, I'd look into how `exportsms.js` processes end level passages to produce config files within `_buildEndLevels`. 
#### How should this be manually tested?

A single competitive story level has been set up [here](https://gist.github.com/tongxiang/88c11d88989c747f2c9b), which you can import into your own version of Twine. Then, when you export the file, you should be able to confirm that the JSON is successfully displayed. 

Does the `ds-mdata-responder` actually work with the new `END-LEVELX` and `END-LEVEL1-GROUP` formats? Yes--this has been tested and confirmed by manually changing the format of the BullyText config file, exporting this config file to my local config database, and then running `npm test.` If you'd like to run this test, see the modified config file [here](https://gist.github.com/tongxiang/8f255703dd77fc8722d5). 
#### What are the relevant tickets?
#9
#### Questions:
1. Does the new `$and`/`$or` configuration of `END-LEVELX-GROUP` objects make sense? Is there a simpler way to accomplish the same goal?
2. TO DO: we still need to figure out how to add the “next_level” property to the end_level1-group object. Perhaps related to this will be figuring out how to pass the story config from one `_build` function to another, in the main global export function. 
