### PR TITLE
add endgame exporter

### DIFF
--- a/js/exportsms.js
+++ b/js/exportsms.js
@@ -25,8 +25,7 @@ var exportsms = function() {
         configData,
         tagName,
         passageType,
-        i,
-        j;
+        i,j;
 
     var config = {},
         regularLevelData = [],
@@ -211,9 +210,7 @@ var exportsms = function() {
         answers,
         next,
         error,
-        i,
-        j,
-        k;
+        i,j,k;
 
 
     if (config.story) {
@@ -289,9 +286,7 @@ var exportsms = function() {
    *   Object of end-level configuration objects. 
    */
   function _buildEndLevels(endLevelData, config) {
-    var i, 
-        j,
-        k,
+    var i,j,k,
         endLevelOutcome, 
         partialStory,
         passageDatum,
@@ -314,7 +309,8 @@ var exportsms = function() {
         ;
 
 
-    for (i = 0; i < endLevelData.length; i++) {    if (config.story) {
+    for (i = 0; i < endLevelData.length; i++) {    
+      if (config.story) {
       partialStory = config.story;
     } 
     else {
@@ -420,15 +416,11 @@ var exportsms = function() {
     var endGameObject,
         endGameDatum,
         endLevelDatum,
-        i,
-        j,
-        k,
-        l,
-        m,
-        n,
-        p,
-        q,
+        i,j,k,
+        min, 
+        max,
         superlativeArray,
+        superlative,
         rank,
         oip,
         choiceObject
@@ -438,9 +430,9 @@ var exportsms = function() {
       "__comments": "",
       "indiv-message-end-game-format": "",
       "group-message-end-game-format": "",
-      "choices": [], // Bully Text format-specific, populated by both endLevelData and endGameData - indivSuperlativePath property in passageEndLevelIndiv, 
-      "group-level-success-oips": [], // Science Sleuth format-specific, populated by endLevelData - groupLevelSuccessOips property in passageEndLevelIndiv
-      "group-success-failure-oips": { // Science Sleuth format-specific, populated by endGameData - minNumLevelSuccess, maxNumLevelSuccess, optinpath properties of passageEndGameGroupSuccessNumberResult
+      "choices": [],
+      "group-level-success-oips": [],
+      "group-success-failure-oips": {
         "0": null,
         "1": null,
         "2": null,
@@ -449,8 +441,8 @@ var exportsms = function() {
         "5": null,
         "6": null
       },
-      "indiv-level-success-oips": [], // Science Sleuth format-specific, populated by endLevelData - indivSuccessPath property in passageEndLevelIndiv
-      "indiv-rank-oips": { // Science Sleuth format-specific, populated by endGameData - rank property in passageEndGameIndivRankResult.js
+      "indiv-level-success-oips": [],
+      "indiv-rank-oips": {
         "1": null,
         "2": null,
         "3": null,
@@ -460,24 +452,24 @@ var exportsms = function() {
       }
     };
 
-    // We also want to iterate through all the endGameData to populate the rest 2) science sleuth indiv rankings, 3) bully text superlatives
-
-    for (j = 0; j < endGameData.length; j++) {
-      endGameDatum = endGameData[j];
-      // If the game data object is from a PassageEndGameIndivResult object 
-      if (endGameDatum.type === 'PassageEndGameIndivRankResult') {
+    // Iterating through all the endgame data.
+    for (i = 0; i < endGameData.length; i++) {
+      endGameDatum = endGameData[i];
+      // Storing oip for an individual rank result.
+      if (endGameDatum.type === PassageEndGameIndivRankResult.prototype.defaults.type) {
         rank = endGameDatum.rank;
         oip = endGameDatum.optinpath;
         endGameObject["indiv-rank-oips"][rank] = oip;
       }
-      // If the game data object is from a PassageEndGameIndivSuperlativeResult
-      else if (endGameDatum.type === 'PassageEndGameIndivSuperlativeResult') {
-        superlative = endGameDatum.pathFlag;
-        for (k = 0; k < endGameObject.choices.length; k++) {
-          if (endGameObject.choices[k].flag == superlative) {
-            choiceObject = endGameObject.choices[k];
+      // Storing oip for an individual superlative result, and setting up the logic choice object. 
+      else if (endGameDatum.type === PassageEndGameIndivSuperlativeResult.prototype.defaults.type) {
+        superlative = endGameDatum.pathflag;
+        for (j = 0; j < endGameObject.choices.length; j++) {
+          if (endGameObject.choices[j].flag == superlative) {
+            choiceObject = endGameObject.choices[j];
           }
         }
+        // Checking that choiceObject doesn't exist or that the namespace isn't already taken by something irrelevant. 
         if (!choiceObject || (choiceObject.flag != superlative)) {
           choiceObject = {
             "next" : '',
@@ -492,38 +484,40 @@ var exportsms = function() {
         endGameObject.choices.push(choiceObject);
       }
 
-      else if (endGameDatum.type === 'PassageEndGameGroupSuccessNumberResult') {
-        min = parseInt(endGameDatum.minNumLevelSuccess);
-        max = parseInt(endGameDatum.maxNumLevelSuccess);
-        for (l = min; l <= max; l++) {
-          endGameObject["group-success-failure-oips"][l] = endGameDatum.optinpath;
+      // Retrieving oip for a group success number result. 
+      else if (endGameDatum.type === PassageEndGameGroupSuccessNumberResult.prototype.defaults.type) {
+        min = parseInt(endGameDatum.minnumlevelsuccess);
+        max = parseInt(endGameDatum.maxnumlevelsuccess);
+        for (k = min; k <= max; k++) {
+          endGameObject["group-success-failure-oips"][k] = endGameDatum.optinpath;
         }
       }
     }
 
-    // We want to iterate through all the 1) endLevelData to build indiv superlative endgame logic, as well as 2) indiv ranking endgame logic, and 3) group success/failure science sleuth game logic. We collect those flags, collect their opt in paths and shove them in an array. 
+    // Iterating through all the endlevel data. 
     for (i = 0; i < endLevelData.length; i++) {
       endLevelDatum = endLevelData[i];
-      // If the game data object is from a PassageEndLevelIndiv object
       if (endLevelDatum.type === 'passageEndLevelIndiv') {
-        if (endLevelDatum.indivSuccessPath == 'true') { // What does this property get expressed as? 
-          endGameObject["indiv-level-success-oips"].push(endLevelDatum.optinpath); // Are we going to need to parseInt() this? 
-        } 
-        else if (endLevelDatum.indivSuperlativePath) {
-          superlativeArray = endLevelDatum.indivSuperlativePath.split(/[ ,]+/);
-          for (p = 0; p < superlativeArray.length; p++) {
-            if (superlativeArray[p]) { // Warding off empty strings. 
-              for (q = 0; q < endGameObject.choices.length; q++) {
-                if (endGameObject.choices[q].flag == superlativeArray[p]) {
-                  endGameObject.choices[q].conditions["$and"].push(endLevelDatum.name);
+        // Storing oip of an individual success level. Used to calculate endgame result of rank among others. 
+        if (endLevelDatum.indivsuccesspath == 'true') {
+          endGameObject["indiv-level-success-oips"].push(endLevelDatum.optinpath);
+        }
+        // Storing the key of a passage which a user must traverse in order to receive a specific superlative endgame result. 
+        if (endLevelDatum.indivsuperlativepath) {
+          superlativeArray = endLevelDatum.indivsuperlativepath.split(/[ ,]+/);
+          for (j = 0; j < superlativeArray.length; j++) {
+            if (superlativeArray[j]) { // Warding off empty strings. 
+              for (k = 0; k < endGameObject.choices.length; k++) {
+                if (endGameObject.choices[k].flag == superlativeArray[j]) {
+                  endGameObject.choices[k].conditions["$and"].push(endLevelDatum.name);
                 }
               }
             }
           }
         }
       } 
-      // If the game data object is from a PassageEndLevelGroup object
-      else if (endLevelDatum.type === 'passageEndLevelGroup') {
+      // Storing the oip of the end level passages which convey a group's success. Used to calculate the group success/failure endgame result. 
+      else if (endLevelDatum.type === 'passageEndLevelGroup' && endLevelDatum.groupsuccesspath == 'true') {
         endGameObject["group-level-success-oips"].push(endLevelDatum.optinpath);
       }
     }


### PR DESCRIPTION
#### What's this PR do?

Adds the ability for a Twine story to export the endgame config object. 
#### How should this be manually tested?

Creating a valid twine story with a few necessary things: 
1. competitive-story story structure 
2. end level individual passages (`passageEndLevelIndiv` objects) with "is this an individual success path?" and "what individual endgame superlative result does this path produce?" properties filled out. 
3. end level group passages (`passageEndLevelGroup` objects) with their "is this a group success path?" filled out. 
4. end game result passages for group success number (`passageEndGameGroupSuccessNumberResult`) added. 
5. end game result passages for individual rankings (`passageEndGameIndivRankingResult`) added. 
6. end game result passages for individual superlatives (`passageEndGameIndivSuperlativeResult`) added. 

**reference image of end-game setup for testing**
[Link to reference image of end-game setup for testing](https://www.dropbox.com/s/9s8z4n0elg79fmo/Screenshot%202015-02-19%2011.41.23.png?dl=0)

Note that the superlative individual end game result (bully text) and the individual ranking end game result (science sleuth) wouldn't occur naturally, but while testing, we can include them both. 
#### Any background context you want to provide?

in order for `ds-mdata-responder` to be able to use the endgame config, one more step is required--to add an endgame config flag generator to the sms exporter. (#35) 
