### PR TITLE
add endgame flags

### DIFF
--- a/js/exportsms.js
+++ b/js/exportsms.js
@@ -423,7 +423,9 @@ var exportsms = function() {
         superlative,
         rank,
         oip,
-        choiceObject
+        choiceObject,
+        endgameIndivFormatSet,
+        endgameGroupFormatSet
         ;
 
     endGameObject = {
@@ -521,6 +523,32 @@ var exportsms = function() {
         endGameObject["group-level-success-oips"].push(endLevelDatum.optinpath);
       }
     }
+
+    endgameIndivFormatSet = false;
+    endgameGroupFormatSet = false;
+
+    // Adding flags. 
+    if (!isEmpty(endGameObject["indiv-rank-oips"]) && endGameObject["indiv-level-success-oips"].length > 0) {
+      endGameObject["indiv-message-end-game-format"] = "rankings-within-group-based";
+      endgameIndivFormatSet = true;
+    }
+
+    if (endGameObject.choices.length > 0) {
+      if (endgameIndivFormatSet) {
+        alert('You\'re trying to enter more than one individual message end game format! This needs to be fixed.');
+      }
+      endGameObject["indiv-message-end-game-format"] = "individual-decision-based";
+      endgameIndivFormatSet = true;
+    }
+
+    if (!isEmpty(endGameObject["group-success-failure-oips"]) && endGameObject["group-level-success-oips"].length > 0) {
+      endGameObject["group-message-end-game-format"] = "group-success-failure-based";
+      endgameGroupFormatSet = true;
+    }
+
+    if (!endgameIndivFormatSet) { alert('No individual endgame result format set!'); }
+    if (!endgameGroupFormatSet) { alert('No group endgame result format set!'); }
+
     config.story["END-GAME"] = endGameObject;
     return config;
   }
@@ -528,5 +556,9 @@ var exportsms = function() {
   return {
     format: format
   };
+
+  function isEmpty(obj){
+    return Object.keys(obj).length === 0;
+  }
 
 }();


### PR DESCRIPTION
#### What's this PR do?

Adds endgame flags, required by the responder to calculate endgame logic, to the endgame config object. 

Because each game can have one of two types of individual endgame messages, if the endgame config object has more than one type of endgame config, the exporter gives us an alert. 
#### How should this be manually tested?

Tested by exporting a game created with only one type of individual endgame message, and then by exporting a game created with two types of individual endgame messages. 
#### What are the relevant tickets?

Closes #35
