### PR TITLE
add changes which allow exported configs to pass responder tests

### DIFF
--- a/app.html
+++ b/app.html
@@ -90,6 +90,7 @@
 <script src="lib/codemirror/js/mode/javascript/javascript.js"></script>
 <script src="lib/codemirror/js/mode/css/css.js"></script>
 
+<script src="js/config.js"></script>
 <script src="js/exportsms.js"></script>
 <script src="js/importsms.js"></script>
 <script src="js/ui.js"></script>

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,3 @@
+// Contains "global" variables. 
+
+var startLevelKey = "L10";

--- a/js/exportsms.js
+++ b/js/exportsms.js
@@ -70,6 +70,7 @@ var exportsms = function() {
       }
     }
 
+    config = _buildStoryConfig(configData, config)
     config = _buildRegularLevels(regularLevelData, config);
     config = _buildEndLevels(endLevelData, config);
     config = _buildEndGame(endLevelData, endGameData, config);

--- a/js/models/passageStoryConfig.js
+++ b/js/models/passageStoryConfig.js
@@ -5,6 +5,7 @@ var PassageStoryConfig = Passage.extend({
     type: 'storyConfig',
     name: 'Story Configuration',
     description: '',
+    story_id: 0,
     alpha_wait_oip: 0,
     alpha_start_ask_oip: 0,
     beta_join_ask_oip: 0,
@@ -33,6 +34,7 @@ var PassageStoryConfig = Passage.extend({
     'name="<%- name %>" position="<%- left %>,<%- top %>" ' +
     'type="<%- type %>" ' +
     'description="<%- description %>" ' +
+    'story_id="<%- story_id %>" ' + 
     'alpha_wait_oip="<%- alpha_wait_oip %>" ' +
     'alpha_start_ask_oip="<%- alpha_start_ask_oip %>" ' +
     'beta_join_ask_oip="<%- beta_join_ask_oip %>" ' +
@@ -59,8 +61,7 @@ var PassageStoryConfig = Passage.extend({
    * @return Array of string names
    */
   links: function(internalOnly) {
-    // @todo Assumes starting node will always be named 'L10'. Is this a poor assumption to make/thing to enforce?
-    return ['L10'];
+    return startLevelKey;
   },
 
   validate: function(attrs) {
@@ -82,6 +83,7 @@ var PassageStoryConfig = Passage.extend({
       top: this.get('top'),
       type: this.get('type'),
       description: this.get('description'),
+      story_id: this.get('story_id'),
       alpha_wait_oip: this.get('alpha_wait_oip'),
       alpha_start_ask_oip: this.get('alpha_start_ask_oip'),
       beta_join_ask_oip: this.get('beta_join_ask_oip'),

--- a/js/views/storyeditview/passageStoryConfigEditor.js
+++ b/js/views/storyeditview/passageStoryConfigEditor.js
@@ -14,6 +14,7 @@ StoryEditView.PassageStoryConfigEditor = Backbone.View.extend({
     this.$('.passageId').val(this.model.id);
     this.$('.passageName').val('Story Configuration');
     this.$('#edit-sc-description').val(this.model.get('description'));
+    this.$('#edit-sc-story-id').val(this.model.get('story_id'));
     this.$('#edit-sc-alpha-wait-oip').val(this.model.get('alpha_wait_oip'));
     this.$('#edit-sc-alpha-start-ask-oip').val(this.model.get('alpha_start_ask_oip'));
     this.$('#edit-sc-beta-join-ask-oip').val(this.model.get('beta_join_ask_oip'));
@@ -48,6 +49,7 @@ StoryEditView.PassageStoryConfigEditor = Backbone.View.extend({
     saveResult = this.model.save({
       name: this.$('.passageName').val(),
       description: this.$('#edit-sc-description').val(),
+      story_id: this.$('#edit-sc-story-id').val(),
       alpha_wait_oip: this.$('#edit-sc-alpha-wait-oip').val(),
       alpha_start_ask_oip: this.$('#edit-sc-alpha-start-ask-oip').val(),
       beta_join_ask_oip: this.$('#edit-sc-beta-join-ask-oip').val(),

--- a/templates/storyeditview/passageEditStoryConfigModal.html
+++ b/templates/storyeditview/passageEditStoryConfigModal.html
@@ -10,6 +10,8 @@
   <div class="content">
     <label for="edit-sc-description">Description</label>
     <input type="text" id="edit-sc-description" class="block fillin">
+    <label for="edit-sc-story-id">ID</label>
+    <input type="text" id="edit-sc-story-id" class="block fillin">
 
     <h3>Start Game Opt-in Paths</h3>
 


### PR DESCRIPTION
#### What's this PR do?

While at first glance, the config files previously exported by intertwine seemed to be able to run games. After setting up an actual science sleuth game in intertwine, storing the produced config in our local config database, and running `npm test`, we (Tong) quickly realized that these config files were **wildly** full of erroneous holes produced by us (Tong). 

What changed? 
1. We added a `story_id` property to `passageStoryConfig.js`, and all the attendant places the new property needs to be. During the `exportsms.js` step, this `story_id` becomes `_id` in the document created. 
2. Within `exportsms.js`, our `_buildStoryConfig` function now also creates a `story_start_oip` property, which we were missing before. 
3. Because we are now referencing the first level name string, `L10`, in more than one place, I created a `config.js` file to store global variables. (Perhaps a place for a hard-coded number of levels?)
4. All necessary opt-in-paths are run through `parseInt()` before exported.
#### Where should the reviewer start?

Most changes are fairly small and easy to understand. The `_buildStoryConfig()` and `_buildRegularLevels` function have the greatest change. 
#### How should this be manually tested?
1. Upload [this HTML gist](https://gist.github.com/tongxiang/cf00bde4fa3c5140046c) of the real McCoy Science Sleuth 2014 SMS game into your version of intertwine. 
2. export it
3. copy-and-paste the exported JSON into your `ds-mdata-responder`'s `competitive-stories.json` file, in place of the old Science Sleuth 2014 game. (**NOT** the A/B test version.)
4. comment out the top section of `pull_config.sh` which imports config files from production, ensuring that the second section--that section which exports JSON config files stored in the app and puts them in your local db--remains. 
5. run `npm test`. Your tests should pass!
#### What are the relevant tickets?

Closes #9!!!
#### Questions:

It seems to me that there might be some obvious refactors. (For instance, finding a more intelligent way to `parseInt()` all exported opt-in-paths.) Let me know if you think of any others. 

Also, I think for the time being it might be reasonable add the `numberOfLevels` param to `config.js` to avoid working on #34 right now, as we prioritize working on validations the rest of this week? What are your thoughts?
