### PR TITLE
playability fix

### DIFF
--- a/js/exportsms.js
+++ b/js/exportsms.js
@@ -217,7 +217,7 @@ var exportsms = function() {
         optinpath,
         key,
         links,
-        answers,
+        answer,
         next,
         error,
         i,j,k,l;
@@ -242,14 +242,15 @@ var exportsms = function() {
 
         for (j = 0; links != null && j < links.length; j++) {
           // Assumes link format is [[display text|link|valid answers]]
-          key = links[j].replace(/\[\[(.+)\|(.+)\|(.+)\]\]/g, '$2');
-          answers = links[j].replace(/\[\[(.+)\|(.+)\|(.+)\]\]/g, '$3');
+          key = links[j].replace(/\[\[(.+)\|(.+)\]\]/g, '$2');
+          // Valid answer will be the last character of the passage's name (key). Ex: "A" for "L1A".
+          answer = key.charAt(key.length - 1);
           next = 0;
 
           // Build the choices array based on the links found
           storyPassage.choices[j] = {};
           storyPassage.choices[j].key = key;
-          storyPassage.choices[j].valid_answers = [answers];
+          storyPassage.choices[j].valid_answers = [answer];
 
           // To get the `next` optinpath, search through all passageData and endLevelData to find the
           // passage.name that matches the key for this choice.

--- a/js/models/passageDS.js
+++ b/js/models/passageDS.js
@@ -46,8 +46,9 @@ var PassageDS = Passage.extend({
       invalidLinks = 0;
 
       for (i = 0; i < matches.length; i++) {
-        // Link format: [[display text|link|valid answer]]
-        link = matches[i].replace(/\[\[(.+)\|(.+)\|(.+)\]\]/g, '$2');
+        // Link format: [[display text|link]]
+
+        link = matches[i].replace(/\[\[([^\|\]]*?)\|([^\|\]]*)?\]\]/g, "$2");
 
         if (link != matches[i] && link.length > 0) {
           result.push(link);


### PR DESCRIPTION
#### What's this PR do?

Allows for custom DS intertwine games to be played. 

The Harlowe formatter only accepts links formatted in specific ways. If we were to continue with our `[[answer|L1A|A]]` syntax, we'd have to significantly modify the Harlowe. Instead, we reverted our links back to the `[[answer|L1A]]` syntax, and our exporter parses the key (`L1A`, or `L2AB`) for the last character. This last character is then stored and used to populate the `valid_answers` array. 

We've also modified the way `passageDS.js` validations occur so that it no longer thinks the two-item keys `[[L1A|A]]` are invalid. 
#### How should this be manually tested?

I'm going to send @jonuy the intertwine game set up with normal two-item keys, which can be used to test that the intertwine game can be played, and then next that the exported game passes all tests with the responder. 
#### What are the relevant tickets?

Closes #42. 
