### PR TITLE
change order of script load for firefox

### DIFF
--- a/app.html
+++ b/app.html
@@ -112,8 +112,6 @@
 <script src="js/collections/storycollection.js"></script>
 <script src="js/collections/storyformatcollection.js"></script>
 
-<script src="preload/preload.js"></script>
-
 <script src="js/views/welcomeview.js"></script>
 <script src="js/views/storyitemview.js"></script>
 <script src="js/views/storylistview/storylistview.js"></script>
@@ -141,6 +139,8 @@
 
 <script src="js/router.js"></script>
 <script src="js/app.js"></script>
+
+<script src="preload/preload.js"></script>
 <!-- endbuild -->
 
 </body>


### PR DESCRIPTION
#### What's this PR do?

While we tested the `preload` PR before and the auto-population of the science sleuth game seemed to work in chrome consistently, the auto-population didn't seem to work in Firefox. This has to do with script load order. 

My hypothesis is that this also had something to do with the way different browsers interpret function expressions. 
#### How should this be manually tested?

The same. Spinning up a local server by running `python -m SimpleHTTPServer 8888` in the directory, and navigating to `localhost:8888` with both Firefox and Chrome. 
#### What are the relevant tickets?

Closes #46.
#### Questions:
