### PR TITLE
add opt in path validations for story passages

### DIFF
--- a/css/intertwine.css
+++ b/css/intertwine.css
@@ -12,3 +12,8 @@
 {
   top: 21.5em;
 }
+
+#storyEditView .passage.brokenOip .frame
+{
+  background-color: hsla(50, 100%, 60%, 0.5);
+}

--- a/js/models/passage.js
+++ b/js/models/passage.js
@@ -71,15 +71,16 @@ var Passage = Backbone.Model.extend(
 
   validate: function (attrs)
   {
-    if (! attrs.name || attrs.name == '')
+    if (! attrs.name || attrs.name == '') {
       return Passage.NO_NAME_ERROR;
-
+    }
     if (this.fetchStory().fetchPassages().find(function (passage)
         {
         return (attrs.id != passage.id &&
             attrs.name.toLowerCase() == passage.get('name').toLowerCase());
-        }))
+        })) {
       return Passage.DUPE_NAME_ERROR.replace('%s', attrs.name);
+    }
   },
 
   /**

--- a/js/models/passageDS.js
+++ b/js/models/passageDS.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var PassageDS = Passage.extend({
+var PassageDS = Passage.extend(
+{
   defaults: {
     type: 'ds',
     top: 0,
@@ -22,7 +23,35 @@ var PassageDS = Passage.extend({
   },
 
   validate: function(attrs) {
+    var returnStatement
+      , thereIsADuplicate
+      , duplicatePassageName
+      , oip;
 
+    returnStatement = Passage.prototype.validate.call(this, attrs)
+
+    oip = attrs.optinpath;
+
+    if (!returnStatement) {
+      // Checks for presence of opt in path value. 
+      if (! oip || oip == '' || oip == 0) {
+        return PassageDS.NO_OIP_ERROR;
+      }
+      // Checks for duplicate opt in paths. 
+      thereIsADuplicate = this.fetchStory().fetchPassages().find(
+        function(passage){
+          duplicatePassageName = passage.name
+          return (attrs.id != passage.id && oip == passage.get('optinpath'));
+        }
+      )
+
+      if (thereIsADuplicate) {
+        return PassageDS.DUPE_OIP_ERROR.replace('%s', duplicatePassageName);
+      }
+
+    }
+
+    return returnStatement;
   },
 
   /**
@@ -93,4 +122,8 @@ var PassageDS = Passage.extend({
     });
   }
 
+},
+{
+  NO_OIP_ERROR: 'You must give this passage an opt-in-path.',
+  DUPE_OIP_ERROR: 'There is already a passage ("%s") with this opt-in-path. Please give this one a unique opt-in-path.'
 });

--- a/js/models/passageDS.js
+++ b/js/models/passageDS.js
@@ -22,35 +22,32 @@ var PassageDS = Passage.extend(
     Passage.prototype.initialize.apply(this);
   },
 
-  validate: function(attrs) {
-    var returnStatement
-      , thereIsADuplicate
-      , duplicatePassageName
-      , oip;
+  // Checks for presence of non-duplicated optin path. 
+  hasValidOptinPath: function() {
+    var oip, 
+        id
+        ;
 
-    returnStatement = Passage.prototype.validate.call(this, attrs)
-    oip = attrs.optinpath;
+    oip = this.get('optinpath');
+    id = this.get('id');
 
-    if (!returnStatement) {
-      // Checks for presence of opt in path value. 
-      if (! oip || oip == '' || oip == 0) {
-        return PassageDS.NO_OIP_ERROR;
-      }
-      // Checks for duplicate opt in paths. 
-      thereIsADuplicate = this.fetchStory().fetchPassages().find(
-        function(passage){
-          duplicatePassageName = passage.get('name');
-          return (attrs.id != passage.id && oip == passage.get('optinpath'));
-        }
-      )
-
-      if (thereIsADuplicate) {
-        return PassageDS.DUPE_OIP_ERROR.replace('%s', duplicatePassageName);
-      }
-
+    if (! oip || oip == '' || oip == 0) {
+      return false;
     }
 
-    return returnStatement;
+    // Checks for duplicate opt in paths. 
+    var hasDuplicate = this.fetchStory().fetchPassages().find(
+      function(passage){
+        if (id != passage.id && oip == passage.get('optinpath')) {
+          return true;
+        }
+      }
+    )
+    return !hasDuplicate;
+  },
+
+  validate: function(attrs) {
+    return Passage.prototype.validate.call(this, attrs);
   },
 
   /**

--- a/js/models/passageDS.js
+++ b/js/models/passageDS.js
@@ -29,7 +29,6 @@ var PassageDS = Passage.extend(
       , oip;
 
     returnStatement = Passage.prototype.validate.call(this, attrs)
-
     oip = attrs.optinpath;
 
     if (!returnStatement) {
@@ -40,7 +39,7 @@ var PassageDS = Passage.extend(
       // Checks for duplicate opt in paths. 
       thereIsADuplicate = this.fetchStory().fetchPassages().find(
         function(passage){
-          duplicatePassageName = passage.name
+          duplicatePassageName = passage.get('name');
           return (attrs.id != passage.id && oip == passage.get('optinpath'));
         }
       )
@@ -125,5 +124,5 @@ var PassageDS = Passage.extend(
 },
 {
   NO_OIP_ERROR: 'You must give this passage an opt-in-path.',
-  DUPE_OIP_ERROR: 'There is already a passage ("%s") with this opt-in-path. Please give this one a unique opt-in-path.'
+  DUPE_OIP_ERROR: 'There is already a passage--"%s"--with this opt-in-path. Please give this one a unique opt-in-path.'
 });

--- a/js/models/passageEndGameGroupSuccessNumberResult.js
+++ b/js/models/passageEndGameGroupSuccessNumberResult.js
@@ -28,7 +28,7 @@ var PassageEndGameGroupSuccessNumberResult = Passage.extend({
   },
 
   validate: function(attrs) {
-
+    return PassageDS.prototype.validate.call(this, attrs);
   },
 
   publish: function(id) {

--- a/js/models/passageEndGameGroupSuccessNumberResult.js
+++ b/js/models/passageEndGameGroupSuccessNumberResult.js
@@ -27,6 +27,10 @@ var PassageEndGameGroupSuccessNumberResult = Passage.extend({
     Passage.prototype.initialize.apply(this);
   },
 
+  hasValidOptinPath: function() {
+    return PassageDS.prototype.hasValidOptinPath.apply(this);
+  },
+
   validate: function(attrs) {
     return PassageDS.prototype.validate.call(this, attrs);
   },

--- a/js/models/passageEndGameIndivRankResult.js
+++ b/js/models/passageEndGameIndivRankResult.js
@@ -25,7 +25,7 @@ var PassageEndGameIndivRankResult = Passage.extend({
   },
 
   validate: function(attrs) {
-
+    return PassageDS.prototype.validate.call(this, attrs);
   },
 
   publish: function(id) {

--- a/js/models/passageEndGameIndivRankResult.js
+++ b/js/models/passageEndGameIndivRankResult.js
@@ -24,6 +24,10 @@ var PassageEndGameIndivRankResult = Passage.extend({
     Passage.prototype.initialize.apply(this);
   },
 
+  hasValidOptinPath: function() {
+    return PassageDS.prototype.hasValidOptinPath.apply(this);
+  },
+
   validate: function(attrs) {
     return PassageDS.prototype.validate.call(this, attrs);
   },

--- a/js/models/passageEndGameIndivSuperlativeResult.js
+++ b/js/models/passageEndGameIndivSuperlativeResult.js
@@ -25,6 +25,10 @@ var PassageEndGameIndivSuperlativeResult = Passage.extend({
     Passage.prototype.initialize.apply(this);
   },
 
+  hasValidOptinPath: function() {
+    return PassageDS.prototype.hasValidOptinPath.apply(this);
+  },
+
   validate: function(attrs) {
     return PassageDS.prototype.validate.call(this, attrs);
   },

--- a/js/models/passageEndGameIndivSuperlativeResult.js
+++ b/js/models/passageEndGameIndivSuperlativeResult.js
@@ -26,7 +26,7 @@ var PassageEndGameIndivSuperlativeResult = Passage.extend({
   },
 
   validate: function(attrs) {
-
+    return PassageDS.prototype.validate.call(this, attrs);
   },
 
   publish: function(id) {

--- a/js/models/passageEndLevelGroup.js
+++ b/js/models/passageEndLevelGroup.js
@@ -23,6 +23,10 @@ var PassageEndLevelGroup = Passage.extend({
     Passage.prototype.initialize.apply(this);
   },
 
+  hasValidOptinPath: function() {
+    return PassageDS.prototype.hasValidOptinPath.apply(this);
+  },
+
   validate: function(attrs) {
     return PassageDS.prototype.validate.call(this, attrs);
   },

--- a/js/models/passageEndLevelGroup.js
+++ b/js/models/passageEndLevelGroup.js
@@ -24,7 +24,7 @@ var PassageEndLevelGroup = Passage.extend({
   },
 
   validate: function(attrs) {
-
+    return PassageDS.prototype.validate.call(this, attrs);
   },
   
   /**

--- a/js/models/passageEndLevelIndiv.js
+++ b/js/models/passageEndLevelIndiv.js
@@ -26,7 +26,7 @@ var PassageEndLevelIndiv = Passage.extend({
   },
 
   validate: function(attrs) {
-
+    return PassageDS.prototype.validate.call(this, attrs);
   },
 
   /**

--- a/js/models/passageEndLevelIndiv.js
+++ b/js/models/passageEndLevelIndiv.js
@@ -25,6 +25,10 @@ var PassageEndLevelIndiv = Passage.extend({
     Passage.prototype.initialize.apply(this);
   },
 
+  hasValidOptinPath: function() {
+    return PassageDS.prototype.hasValidOptinPath.apply(this);
+  },
+
   validate: function(attrs) {
     return PassageDS.prototype.validate.call(this, attrs);
   },

--- a/js/views/passageitemview.js
+++ b/js/views/passageitemview.js
@@ -105,6 +105,13 @@ var PassageItemView = Marionette.ItemView.extend(
     else
       this.$el.addClass('brokenLink');
 
+    // set CSS class for missing or duplicated OIPs
+    if (typeof this.model.hasValidOptinPath == 'function' && !this.model.hasValidOptinPath()) {
+      this.$el.addClass('brokenOip');
+    }
+    else {
+      this.$el.removeClass('brokenOip');
+    }
     // set CSS class for starting point
 
     if (this.parentView.model.get('startPassage') == this.model.id)

--- a/js/views/storyeditview/passageDSEditor.js
+++ b/js/views/storyeditview/passageDSEditor.js
@@ -10,6 +10,9 @@ StoryEditView.PassageDSEditor = Backbone.View.extend({
    * Opens modal dialog for editing the passage.
    */
   open: function() {
+    this.prevTitle = document.title;
+    document.title = this.model.get('name');
+
     this.$('.passageId').val(this.model.id);
     this.$('.passageName').val(this.model.get('name'));
     var text = this.model.get('text');
@@ -17,6 +20,9 @@ StoryEditView.PassageDSEditor = Backbone.View.extend({
     this.$('#edit-ds-oip').val(this.model.get('optinpath'));
 
     this.$el.data('modal').trigger('show');
+
+    var message = this.$('.error');
+    message.css('display', 'none');
   },
 
   /**
@@ -35,6 +41,7 @@ StoryEditView.PassageDSEditor = Backbone.View.extend({
    */
   save: function(e) {
     var saveResult;
+    var message = this.$('.error');
 
     saveResult = this.model.save({
       name: this.$('.passageName').val(),
@@ -44,9 +51,13 @@ StoryEditView.PassageDSEditor = Backbone.View.extend({
 
     if (saveResult) {
       this.$('.alert').remove();
+      message.css('display', 'none');
     }
     else {
-      // @todo show error message
+      var message = this.$('.error');
+      message.css('display', 'block').text(this.model.validationError);
+      this.$('.passageName').focus();
+      alert(this.model.validationError);
     }
 
     if (e) {

--- a/js/views/storyeditview/passageDSEditor.js
+++ b/js/views/storyeditview/passageDSEditor.js
@@ -56,7 +56,6 @@ StoryEditView.PassageDSEditor = Backbone.View.extend({
     else {
       var message = this.$('.error');
       message.css('display', 'block').text(this.model.validationError);
-      this.$('.passageName').focus();
       alert(this.model.validationError);
     }
 

--- a/js/views/storyeditview/passageEndGameGroupSuccessNumberResultEditor.js
+++ b/js/views/storyeditview/passageEndGameGroupSuccessNumberResultEditor.js
@@ -10,6 +10,9 @@ StoryEditView.PassageEndGameGroupSuccessNumberResultEditor = Backbone.View.exten
    * Opens modal dialog for editing the passage.
    */
   open: function() {
+    this.prevTitle = document.title;
+    document.title = this.model.get('name');
+
     this.$('.passageId').val(this.model.id);
     this.$('.passageName').val(this.model.get('name'));
     var text = this.model.get('text');
@@ -19,6 +22,9 @@ StoryEditView.PassageEndGameGroupSuccessNumberResultEditor = Backbone.View.exten
     this.$('#edit-max-num-group-success').val(this.model.get('maxNumLevelSuccess'));
 
     this.$el.data('modal').trigger('show');
+
+    var message = this.$('.error');
+    message.css('display', 'none');
   },
 
   /**
@@ -37,6 +43,7 @@ StoryEditView.PassageEndGameGroupSuccessNumberResultEditor = Backbone.View.exten
    */
   save: function(e) {
     var saveResult;
+    var message = this.$('.error');
 
     saveResult = this.model.save({
       name: this.$('.passageName').val(),
@@ -48,9 +55,13 @@ StoryEditView.PassageEndGameGroupSuccessNumberResultEditor = Backbone.View.exten
 
     if (saveResult) {
       this.$('.alert').remove();
+      message.css('display', 'none');
     }
     else {
-      // @todo show error message
+      var message = this.$('.error');
+      message.css('display', 'block').text(this.model.validationError);
+      this.$('.passageName').focus();
+      alert(this.model.validationError);
     }
 
     if (e) {

--- a/js/views/storyeditview/passageEndGameGroupSuccessNumberResultEditor.js
+++ b/js/views/storyeditview/passageEndGameGroupSuccessNumberResultEditor.js
@@ -60,7 +60,6 @@ StoryEditView.PassageEndGameGroupSuccessNumberResultEditor = Backbone.View.exten
     else {
       var message = this.$('.error');
       message.css('display', 'block').text(this.model.validationError);
-      this.$('.passageName').focus();
       alert(this.model.validationError);
     }
 

--- a/js/views/storyeditview/passageEndGameIndivRankResultEditor.js
+++ b/js/views/storyeditview/passageEndGameIndivRankResultEditor.js
@@ -57,7 +57,6 @@ StoryEditView.PassageEndGameIndivRankResultEditor = Backbone.View.extend({
     else {
       var message = this.$('.error');
       message.css('display', 'block').text(this.model.validationError);
-      this.$('.passageName').focus();
       alert(this.model.validationError);
     }
 

--- a/js/views/storyeditview/passageEndGameIndivRankResultEditor.js
+++ b/js/views/storyeditview/passageEndGameIndivRankResultEditor.js
@@ -10,6 +10,9 @@ StoryEditView.PassageEndGameIndivRankResultEditor = Backbone.View.extend({
    * Opens modal dialog for editing the passage.
    */
   open: function() {
+    this.prevTitle = document.title;
+    document.title = this.model.get('name');
+
     this.$('.passageId').val(this.model.id);
     this.$('.passageName').val(this.model.get('name'));
     var text = this.model.get('text');
@@ -17,6 +20,9 @@ StoryEditView.PassageEndGameIndivRankResultEditor = Backbone.View.extend({
     this.$('#edit-ds-oip').val(this.model.get('optinpath'));
     this.$('#rank').val(this.model.get('rank'));
     this.$el.data('modal').trigger('show');
+
+    var message = this.$('.error');
+    message.css('display', 'none');
   },
 
   /**
@@ -35,6 +41,7 @@ StoryEditView.PassageEndGameIndivRankResultEditor = Backbone.View.extend({
    */
   save: function(e) {
     var saveResult;
+    var message = this.$('.error');
 
     saveResult = this.model.save({
       name: this.$('.passageName').val(),
@@ -45,9 +52,13 @@ StoryEditView.PassageEndGameIndivRankResultEditor = Backbone.View.extend({
 
     if (saveResult) {
       this.$('.alert').remove();
+      message.css('display', 'none');
     }
     else {
-      // @todo show error message
+      var message = this.$('.error');
+      message.css('display', 'block').text(this.model.validationError);
+      this.$('.passageName').focus();
+      alert(this.model.validationError);
     }
 
     if (e) {

--- a/js/views/storyeditview/passageEndGameIndivSuperlativeResultEditor.js
+++ b/js/views/storyeditview/passageEndGameIndivSuperlativeResultEditor.js
@@ -10,6 +10,9 @@ StoryEditView.PassageEndGameIndivSuperlativeResultEditor = Backbone.View.extend(
    * Opens modal dialog for editing the passage.
    */
   open: function() {
+    this.prevTitle = document.title;
+    document.title = this.model.get('name');
+
     this.$('.passageId').val(this.model.id);
     this.$('.passageName').val(this.model.get('name'));
     var text = this.model.get('text');
@@ -17,6 +20,9 @@ StoryEditView.PassageEndGameIndivSuperlativeResultEditor = Backbone.View.extend(
     this.$('#edit-ds-oip').val(this.model.get('optinpath'));
     this.$('#path-flag').val(this.model.get('pathFlag'));
     this.$el.data('modal').trigger('show');
+
+    var message = this.$('.error');
+    message.css('display', 'none');
   },
 
   /**
@@ -35,6 +41,7 @@ StoryEditView.PassageEndGameIndivSuperlativeResultEditor = Backbone.View.extend(
    */
   save: function(e) {
     var saveResult;
+    var message = this.$('.error');
 
     saveResult = this.model.save({
       name: this.$('.passageName').val(),
@@ -45,9 +52,13 @@ StoryEditView.PassageEndGameIndivSuperlativeResultEditor = Backbone.View.extend(
 
     if (saveResult) {
       this.$('.alert').remove();
+      message.css('display', 'none');
     }
     else {
-      // @todo show error message
+      var message = this.$('.error');
+      message.css('display', 'block').text(this.model.validationError);
+      this.$('.passageName').focus();
+      alert(this.model.validationError);
     }
 
     if (e) {

--- a/js/views/storyeditview/passageEndGameIndivSuperlativeResultEditor.js
+++ b/js/views/storyeditview/passageEndGameIndivSuperlativeResultEditor.js
@@ -57,7 +57,6 @@ StoryEditView.PassageEndGameIndivSuperlativeResultEditor = Backbone.View.extend(
     else {
       var message = this.$('.error');
       message.css('display', 'block').text(this.model.validationError);
-      this.$('.passageName').focus();
       alert(this.model.validationError);
     }
 

--- a/js/views/storyeditview/passageEndLevelGroupEditor.js
+++ b/js/views/storyeditview/passageEndLevelGroupEditor.js
@@ -10,6 +10,9 @@ StoryEditView.PassageEndLevelGroupEditor = Backbone.View.extend({
    * Opens modal dialog for editing the passage.
    */
   open: function() {
+    this.prevTitle = document.title;
+    document.title = this.model.get('name');
+
     this.$('.passageId').val(this.model.id);
     this.$('.passageName').val(this.model.get('name'));
     var text = this.model.get('text');
@@ -18,6 +21,9 @@ StoryEditView.PassageEndLevelGroupEditor = Backbone.View.extend({
     this.$('#edit-group-success-path').val(this.model.get('groupSuccessPath'));
 
     this.$el.data('modal').trigger('show');
+
+    var message = this.$('.error');
+    message.css('display', 'none');
   },
 
   /**
@@ -35,6 +41,7 @@ StoryEditView.PassageEndLevelGroupEditor = Backbone.View.extend({
    */
   save: function(e) {
     var saveResult;
+    var message = this.$('.error');
 
     saveResult = this.model.save({
       name: this.$('.passageName').val(),
@@ -45,9 +52,13 @@ StoryEditView.PassageEndLevelGroupEditor = Backbone.View.extend({
 
     if (saveResult) {
       this.$('.alert').remove();
+      message.css('display', 'none');
     }
     else {
-      // @todo show error message
+      var message = this.$('.error');
+      message.css('display', 'block').text(this.model.validationError);
+      this.$('.passageName').focus();
+      alert(this.model.validationError);
     }
 
     if (e) {

--- a/js/views/storyeditview/passageEndLevelGroupEditor.js
+++ b/js/views/storyeditview/passageEndLevelGroupEditor.js
@@ -57,7 +57,6 @@ StoryEditView.PassageEndLevelGroupEditor = Backbone.View.extend({
     else {
       var message = this.$('.error');
       message.css('display', 'block').text(this.model.validationError);
-      this.$('.passageName').focus();
       alert(this.model.validationError);
     }
 

--- a/js/views/storyeditview/passageEndLevelIndivEditor.js
+++ b/js/views/storyeditview/passageEndLevelIndivEditor.js
@@ -10,6 +10,9 @@ StoryEditView.PassageEndLevelIndivEditor = Backbone.View.extend({
    * Opens modal dialog for editing the passage.
    */
   open: function() {
+    this.prevTitle = document.title;
+    document.title = this.model.get('name');
+
     this.$('.passageId').val(this.model.id);
     this.$('.passageName').val(this.model.get('name'));
     var text = this.model.get('text');
@@ -19,6 +22,9 @@ StoryEditView.PassageEndLevelIndivEditor = Backbone.View.extend({
     this.$('#edit-indiv-superlative-path').val(this.model.get('indivSuperlativePath'));
 
     this.$el.data('modal').trigger('show');
+
+    var message = this.$('.error');
+    message.css('display', 'none');
   },
 
 
@@ -37,6 +43,7 @@ StoryEditView.PassageEndLevelIndivEditor = Backbone.View.extend({
    */
   save: function(e) {
     var saveResult;
+    var message = this.$('.error');
 
     saveResult = this.model.save({
       name: this.$('.passageName').val(),
@@ -48,9 +55,13 @@ StoryEditView.PassageEndLevelIndivEditor = Backbone.View.extend({
 
     if (saveResult) {
       this.$('.alert').remove();
+      message.css('display', 'none');
     }
     else {
-      // @todo show error message
+      var message = this.$('.error');
+      message.css('display', 'block').text(this.model.validationError);
+      this.$('.passageName').focus();
+      alert(this.model.validationError);
     }
 
     if (e) {

--- a/js/views/storyeditview/passageEndLevelIndivEditor.js
+++ b/js/views/storyeditview/passageEndLevelIndivEditor.js
@@ -60,7 +60,6 @@ StoryEditView.PassageEndLevelIndivEditor = Backbone.View.extend({
     else {
       var message = this.$('.error');
       message.css('display', 'block').text(this.model.validationError);
-      this.$('.passageName').focus();
       alert(this.model.validationError);
     }
 

--- a/js/views/storyeditview/passageeditor.js
+++ b/js/views/storyeditview/passageeditor.js
@@ -113,7 +113,6 @@ StoryEditView.PassageEditor = Backbone.View.extend(
     }
     else {
       message.css('display', 'block').text(this.model.validationError);
-      this.$('.passageName').focus();
       alert(this.model.validationError);
     };
   },

--- a/js/views/storyeditview/passageeditor.js
+++ b/js/views/storyeditview/passageeditor.js
@@ -64,6 +64,9 @@ StoryEditView.PassageEditor = Backbone.View.extend(
     _.each(this.model.get('tags'), this.addTag, this);
 
     this.$el.data('modal').trigger('show');
+
+    var message = this.$('.error');
+    message.css('display', 'none');
   },
 
   /**
@@ -91,6 +94,7 @@ StoryEditView.PassageEditor = Backbone.View.extend(
     // gather current tag names
 
     var tags = [];
+    var message = this.$('.error');
 
     this.$('.passageTags .tag').each(function()
     {
@@ -103,26 +107,14 @@ StoryEditView.PassageEditor = Backbone.View.extend(
       name: this.$('.passageName').val(),
       text: this.$('.passageText').val(),
       tags: tags
-    }))
-      this.$('.alert').remove();
-    else
-    {
-      // show the error message
-
-      var message = this.$('.alert');
-      
-      if (message.size() == 0)
-        message = $('<p class="alert alert-danger">')
-        .text(this.model.validationError);
-
-      this.$('.textareaContainer').before(message);
-      message.hide().fadeIn();
+    })){
+      this.$('.error').addClass('hide').hide();
+      message.css('display', 'none');
+    }
+    else {
+      message.css('display', 'block').text(this.model.validationError);
       this.$('.passageName').focus();
-
-      // if we are handling an event, stop it
-
-      if (e)
-        e.stopImmediatePropagation();
+      alert(this.model.validationError);
     };
   },
 

--- a/templates/storyeditview/passageEditDSModal.html
+++ b/templates/storyeditview/passageEditDSModal.html
@@ -8,6 +8,9 @@
   </p>
 
   <div class="content">
+
+    <p class="error hide"></p>
+
     <label for="edit-ds-oip">Mobile Commons Opt-in Path</label>
     <input type="number" id="edit-ds-oip" name="ds-oip" class="block fillin" placeholder="Opt-in Path">
 

--- a/templates/storyeditview/passageEditEndGameGroupSuccessNumberResultModal.html
+++ b/templates/storyeditview/passageEditEndGameGroupSuccessNumberResultModal.html
@@ -8,6 +8,9 @@
   </p>
 
   <div class="content">
+
+    <p class="error hide"></p>
+
     <label for="edit-ds-oip">Mobile Commons Opt-in Path</label>
     <input type="number" id="edit-ds-oip" name="ds-oip" class="block fillin" placeholder="Opt-in Path">
 

--- a/templates/storyeditview/passageEditEndGameIndivRankResultModal.html
+++ b/templates/storyeditview/passageEditEndGameIndivRankResultModal.html
@@ -8,6 +8,9 @@
   </p>
 
   <div class="content">
+
+    <p class="error hide"></p>
+
     <label for="edit-ds-oip">Mobile Commons Opt-in Path</label>
     <input type="number" id="edit-ds-oip" name="ds-oip" class="block fillin" placeholder="Opt-in Path">
 

--- a/templates/storyeditview/passageEditEndGameIndivSuperlativeResultModal.html
+++ b/templates/storyeditview/passageEditEndGameIndivSuperlativeResultModal.html
@@ -8,6 +8,9 @@
   </p>
 
   <div class="content">
+
+    <p class="error hide"></p>
+
     <label for="edit-ds-oip">Mobile Commons Opt-in Path</label>
     <input type="number" id="edit-ds-oip" name="ds-oip" class="block fillin" placeholder="Opt-in Path">
 

--- a/templates/storyeditview/passageEditEndLevelGroupModal.html
+++ b/templates/storyeditview/passageEditEndLevelGroupModal.html
@@ -8,6 +8,9 @@
   </p>
 
   <div class="content">
+
+    <p class="error hide"></p>
+
     <label for="edit-ds-oip">Mobile Commons Opt-in Path</label>
     <input type="number" id="edit-ds-oip" name="ds-oip" class="block fillin" placeholder="Opt-in Path">
 

--- a/templates/storyeditview/passageEditEndLevelIndivModal.html
+++ b/templates/storyeditview/passageEditEndLevelIndivModal.html
@@ -8,6 +8,9 @@
   </p>
 
   <div class="content">
+
+    <p class="error hide"></p>
+
     <label for="edit-ds-oip">Mobile Commons Opt-in Path</label>
     <input type="number" id="edit-ds-oip" name="ds-oip" class="block fillin" placeholder="Opt-in Path">
 

--- a/templates/storyeditview/passageeditmodal.html
+++ b/templates/storyeditview/passageeditmodal.html
@@ -10,6 +10,8 @@
 
 <div class="content">
 
+<p class="error hide"></p>
+
 <div class="passageTags">
 <form>
 <p>


### PR DESCRIPTION
#### What's this PR do?

This PR adds validation functionality. Once merged it, intertwine will validate that opt-in-path fields for a given custom passage is both **completed** and **unique**. (Validations have not yet been implemented for the story config passage.) 
#### Where should the reviewer start?

The meat of the custom validations is happening in `passageDS.js`. Other custom passages call its `validate` function. 

Each passage's `editor.js` and edit view .html modal have been modified to support the display of validation errors. 
#### How should this be manually tested?

By creating a new game, creating each custom passage type, and testing the following conditions: 
1. If a validation alert displays when the passage has no name. 
2. If an alert displays when the passage has no opt in path. 
3. If an alert displays when the passage has a duplicate opt in path. (Another passage already has the same opt in path.) 
#### Any background context you want to provide?

There are some limitations. 
1. Validations only run when backbone runs its `.set` function (which runs when the framework wants to evaluate state.) This only happens when passages are clicked on to be viewed, or when the passage edit view is exited. So if we were just to open the story edit view, we wouldn't be able to see any of the validations run. 
2. Opt in path validations aren't sophisticated. At all. They just test presence--is there a unique number there? 
3. Story config passage still doesn't have validations. 
#### What are the relevant tickets?

Closes #50. 
