### PR TITLE
add beta_joined_notify_other_betas_oip param to story config passage

### DIFF
--- a/js/exportsms.js
+++ b/js/exportsms.js
@@ -176,6 +176,7 @@ var exportsms = function() {
       }
     }
 
+    // @todo: use Object.keys to run through and assign properties, instead of hard-coding solution below
     config.__comments               = configData.description || '';
     config._id                      = parseInt(configData.story_id, 10) || 0;
     config.alpha_wait_oip           = parseInt(configData.alpha_wait_oip, 10) || 0;
@@ -193,6 +194,7 @@ var exportsms = function() {
     config.mobile_create.invalid_mobile_oip     = parseInt(configData.mc_invalid_mobile_oip, 10) || 0;
     config.mobile_create.not_enough_players_oip = parseInt(configData.mc_not_enough_players_oip, 10) || 0;
     config._twinedata                           = configData._twinedata;
+    config.beta_joined_notify_other_betas_oip   = parseInt(configData.beta_joined_notify_other_betas_oip, 10) || 0;
 
     return config;
   }

--- a/js/models/passageStoryConfig.js
+++ b/js/models/passageStoryConfig.js
@@ -9,6 +9,7 @@ var PassageStoryConfig = Passage.extend({
     alpha_wait_oip: 0,
     alpha_start_ask_oip: 0,
     beta_join_ask_oip: 0,
+    beta_joined_notify_other_betas_oip: 0,
     beta_wait_oip: 0,
     game_in_progress_oip: 0,
     game_ended_from_exit_oip: 0,
@@ -38,6 +39,7 @@ var PassageStoryConfig = Passage.extend({
     'alpha_wait_oip="<%- alpha_wait_oip %>" ' +
     'alpha_start_ask_oip="<%- alpha_start_ask_oip %>" ' +
     'beta_join_ask_oip="<%- beta_join_ask_oip %>" ' +
+    'beta_joined_notify_other_betas_oip="<%- beta_joined_notify_other_betas_oip %>" ' +
     'beta_wait_oip="<%- beta_wait_oip %>" ' +
     'game_in_progress_oip="<%- game_in_progress_oip %>" ' +
     'game_ended_from_exit_oip="<%- game_ended_from_exit_oip %>" ' +
@@ -87,6 +89,7 @@ var PassageStoryConfig = Passage.extend({
       alpha_wait_oip: this.get('alpha_wait_oip'),
       alpha_start_ask_oip: this.get('alpha_start_ask_oip'),
       beta_join_ask_oip: this.get('beta_join_ask_oip'),
+      beta_joined_notify_other_betas_oip: this.get('beta_joined_notify_other_betas_oip'),
       beta_wait_oip: this.get('beta_wait_oip'),
       game_in_progress_oip: this.get('game_in_progress_oip'),
       game_ended_from_exit_oip: this.get('game_ended_from_exit_oip'),

--- a/js/views/storyeditview/passageStoryConfigEditor.js
+++ b/js/views/storyeditview/passageStoryConfigEditor.js
@@ -18,6 +18,7 @@ StoryEditView.PassageStoryConfigEditor = Backbone.View.extend({
     this.$('#edit-sc-alpha-wait-oip').val(this.model.get('alpha_wait_oip'));
     this.$('#edit-sc-alpha-start-ask-oip').val(this.model.get('alpha_start_ask_oip'));
     this.$('#edit-sc-beta-join-ask-oip').val(this.model.get('beta_join_ask_oip'));
+    this.$('#edit-sc-beta-joined-notify-other-betas-oip').val(this.model.get('beta_joined_notify_other_betas_oip'));
     this.$('#edit-sc-beta-wait-oip').val(this.model.get('beta_wait_oip'));
     this.$('#edit-sc-game-in-progress-oip').val(this.model.get('game_in_progress_oip'));
     this.$('#edit-sc-game-ended-from-exit-oip').val(this.model.get('game_ended_from_exit_oip'));
@@ -53,6 +54,7 @@ StoryEditView.PassageStoryConfigEditor = Backbone.View.extend({
       alpha_wait_oip: this.$('#edit-sc-alpha-wait-oip').val(),
       alpha_start_ask_oip: this.$('#edit-sc-alpha-start-ask-oip').val(),
       beta_join_ask_oip: this.$('#edit-sc-beta-join-ask-oip').val(),
+      beta_joined_notify_other_betas_oip: this.$('#edit-sc-beta-joined-notify-other-betas-oip').val(),
       beta_wait_oip: this.$('#edit-sc-beta-wait-oip').val(),
       game_in_progress_oip: this.$('#edit-sc-game-in-progress-oip').val(),
       game_ended_from_exit_oip: this.$('#edit-sc-game-ended-from-exit-oip').val(),

--- a/templates/storyeditview/passageEditStoryConfigModal.html
+++ b/templates/storyeditview/passageEditStoryConfigModal.html
@@ -27,6 +27,9 @@
     <label for="edit-sc-beta-join-ask-oip">Beta Join Ask OIP</label>
     <input type="number" id="edit-sc-beta-join-ask-oip" name="sc-beta-join-ask-oip" class="block fillin">
 
+    <label for="beta-joined-notify-other-betas-oip">Beta Joined Notify Other Betas</label>
+    <input type="number" id="edit-sc-beta-joined-notify-other-betas-oip" name="sc-beta-joined-notify-other-betas-oip" class="block fillin">
+
     <h3>Ask if player wants to go solo</h3>
 
     <label for="edit-sc-ask-solo-play">Ask Solo Play OIP</label>


### PR DESCRIPTION
#### What's this PR do?

Adds a new parameter to the story config passage. 
#### How should this be manually tested?

Run Intertwine on a local server (`python -m SimpleHTTPServer`), add a `beta_joined_notify_other_betas_oip` value to a story config passage, and then export to check that it's successfully exported. 
#### Any background context you want to provide?

This is necessary for adding player names to the SMS games onboarding process. 
#### What are the relevant tickets?

Closes #53.
